### PR TITLE
add Ibis DuckDB Overturemaps udf

### DIFF
--- a/public/Ibis_DuckDB_Overturemaps/Ibis_DuckDB_Overturemaps.py
+++ b/public/Ibis_DuckDB_Overturemaps/Ibis_DuckDB_Overturemaps.py
@@ -1,0 +1,42 @@
+@fused.udf
+def udf(bbox: fused.types.ViewportGDF):
+    import duckdb
+    import ibis
+    from ibis import _
+
+    @fused.cache 
+    def read_data(bbox, url, con):
+
+        minx, miny, maxx, maxy = bbox.bounds.values[0]
+
+        t = con.read_parquet(url, table_name="infra-usa")
+        
+        expr = t.filter(
+            _.bbox.xmin > minx,
+            _.bbox.ymin > miny,
+            _.bbox.xmax < maxx,
+            _.bbox.ymax < maxy,
+            _.subtype.isin(["pedestrian", "water"]),
+        ).select(["geometry", "subtype", "class"])
+        
+        return expr
+
+
+    con_ddb = ibis.duckdb.connect()
+    url = (
+        "s3://overturemaps-us-west-2/release/2024-11-13.0/theme=base/type=infrastructure/*"
+        )
+
+    info = read_data(bbox, url, con_ddb)
+    info = info.rename(infra_class="class")
+
+    info = info.filter(info.infra_class.isin(["toilets", 
+                                             "drinking_water",
+                                             "bench"]))
+     
+    print(info.infra_class.value_counts().to_pandas())
+
+    gdf = info.to_pandas()
+
+
+    return gdf

--- a/public/Ibis_DuckDB_Overturemaps/README.MD
+++ b/public/Ibis_DuckDB_Overturemaps/README.MD
@@ -1,0 +1,3 @@
+<!--fused:readme-->
+Exported from Fused UDF Workbench
+

--- a/public/Ibis_DuckDB_Overturemaps/meta.json
+++ b/public/Ibis_DuckDB_Overturemaps/meta.json
@@ -1,0 +1,77 @@
+{
+  "version": "0.0.3",
+  "job_config": {
+    "version": "0.0.3",
+    "name": null,
+    "steps": [
+      {
+        "type": "udf",
+        "udf": {
+          "type": "geopandas_v2",
+          "name": "Ibis_DuckDB_Overturemaps",
+          "entrypoint": "udf",
+          "parameters": {},
+          "metadata": {
+            "fused:defaultViewState": {
+              "enable": true,
+              "latitude": 52.37695099999998,
+              "longitude": 4.921399000000035,
+              "zoom": 12,
+              "pitch": 0,
+              "bearing": 0
+            },
+            "fused:vizConfig": {
+              "tileLayer": {
+                "@@type": "TileLayer",
+                "minZoom": 0,
+                "maxZoom": 19,
+                "tileSize": 256,
+                "pickable": true
+              },
+              "rasterLayer": {
+                "@@type": "BitmapLayer",
+                "pickable": true
+              },
+              "vectorLayer": {
+                "@@type": "GeoJsonLayer",
+                "stroked": true,
+                "filled": true,
+                "pickable": true,
+                "lineWidthMinPixels": 2,
+                "pointRadiusMinPixels": 1,
+                "getLineColor": {
+                  "@@function": "colorCategories",
+                  "attr": "infra_class",
+                  "domain": [
+                    "toilets",
+                    "bench",
+                    "drinking_water"
+                  ],
+                  "colors": "Bold",
+                  "nullColor": [
+                    184,
+                    184,
+                    184
+                  ]
+                },
+                "getFillColor": [
+                  208,
+                  208,
+                  208,
+                  40
+                ]
+              }
+            },
+            "fused:udfType": "auto",
+            "fused:slug": "Ibis_DuckDB_Overturemaps",
+            "fused:name": "Ibis_DuckDB_Overturemaps",
+            "fused:id": null
+          },
+          "source": "Ibis_DuckDB_Overturemaps.py",
+          "headers": []
+        }
+      }
+    ],
+    "metadata": null
+  }
+}


### PR DESCRIPTION
This PR adds a new udf that shows how to query data from Overture Maps  using Ibis with the DuckDB engine as a backend. 

cc: @pgzmnk 