### PR TITLE
Fix comments and cleanup ibis-ddb-overture udf

### DIFF
--- a/public/Ibis_DuckDB_Overturemaps/Ibis_DuckDB_Overturemaps.py
+++ b/public/Ibis_DuckDB_Overturemaps/Ibis_DuckDB_Overturemaps.py
@@ -3,7 +3,7 @@ def udf(bbox: fused.types.ViewportGDF = None):
     import ibis
     from ibis import _
 
-    # Instantiate Ibis client
+    # Connect to an in-memory database
     con = ibis.duckdb.connect()
 
     # Overture S3 bucket
@@ -40,12 +40,9 @@ def udf(bbox: fused.types.ViewportGDF = None):
             [
                 "toilets",
                 "atm",
-                "information",
-                "vending_machine",
-                "fountain",
-                "viewpoint",
-                "post_box",
                 "drinking_water",
+                "information",
+                "vending_machine"
             ]
         )
     )
@@ -53,5 +50,5 @@ def udf(bbox: fused.types.ViewportGDF = None):
     # Show value counts
     print(ibis_table.infra_class.value_counts().to_pandas())
 
-    # Return as Pandas
+    # Return as GeoPandas
     return ibis_table.to_pandas()

--- a/public/Ibis_DuckDB_Overturemaps/meta.json
+++ b/public/Ibis_DuckDB_Overturemaps/meta.json
@@ -44,16 +44,16 @@
                   "attr": "infra_class",
                   "domain": [
                     "toilets",
+                    "atm",
+                    "drinking_water",
+                    "information",
+                    "vending_machine",
                     "weir",
                     "dam",
-                    "atm",
-                    "information",
                     "bench",
-                    "vending_machine",
                     "fountain",
                     "viewpoint",
-                    "post_box",
-                    "drinking_water"
+                    "post_box"
                   ],
                   "colors": "Bold",
                   "nullColor": [


### PR DESCRIPTION
I modify some comments that were added that are not accurate and made a one of the filters smaller, to avoid a crowded plot that it's hard to read, and rearrange the meta.json, to make sure that drinking_water falls on the blue color, of the color map

@pgzmnk
