### PR TITLE
update public UDFs containing bbox parameter to include typing

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Files relevant to each UDF are:
 import fused
 
 @fused.udf
-def my_udf(bbox=None):
+def my_udf(bbox: fused.types.TileGDF = None):
     import pandas as pd
     return pd.DataFrame({'Hello': ['from Fused']})
 

--- a/public/Blank_Basemap/Blank_Basemap.py
+++ b/public/Blank_Basemap/Blank_Basemap.py
@@ -1,3 +1,3 @@
 @fused.udf
-def udf(bbox):
+def udf(bbox: fused.types.TileGDF):
     return bbox

--- a/public/Building_Tile_Example/Building_Tile_Example.py
+++ b/public/Building_Tile_Example/Building_Tile_Example.py
@@ -1,5 +1,5 @@
 @fused.udf
-def udf(bbox, table_path="s3://fused-asset/infra/building_msft_us"):
+def udf(bbox: fused.types.TileGDF, table_path="s3://fused-asset/infra/building_msft_us"):
     utils = fused.load(
         "https://github.com/fusedio/udfs/tree/f928ee1/public/common/"
     ).utils

--- a/public/Compute_TWI/Compute_TWI.py
+++ b/public/Compute_TWI/Compute_TWI.py
@@ -17,7 +17,7 @@ wbt_args = {
 min_max = (0, 15)
 
 @fused.udf
-def udf(bbox, out_tif_name: str ='output', wbt_args: dict = wbt_args, min_max=min_max):
+def udf(bbox: fused.types.TileGDF, out_tif_name: str ='output', wbt_args: dict = wbt_args, min_max=min_max):
     import wbt
     wbt_args = json.loads(wbt_args) if isinstance(wbt_args, str) else wbt_args
     return wbt.run(bbox, wbt_args, out_tif_name, extra_input_files=None, min_max=min_max)

--- a/public/DSM_Zonal_Stats/DSM_Zonal_Stats.py
+++ b/public/DSM_Zonal_Stats/DSM_Zonal_Stats.py
@@ -1,6 +1,6 @@
 @fused.udf
 def udf(
-    bbox, min_zoom=15, table="s3://fused-asset/infra/building_msft_us/", chip_len=256
+    bbox: fused.types.TileGDF, min_zoom=15, table="s3://fused-asset/infra/building_msft_us/", chip_len=256
 ):
     import utils
 

--- a/public/DuckDB_H3_Example/DuckDB_H3_Example.py
+++ b/public/DuckDB_H3_Example/DuckDB_H3_Example.py
@@ -1,6 +1,6 @@
 # Note: This UDF is only for demo purposes. You may get `HTTP GET error` after several times calling it. This is the data retrieval issue caused by Cloudfront servers not responding.
 @fused.udf
-def udf(bbox=None, resolution: int = 9, min_count: int = 10):
+def udf(bbox: fused.types.TileGDF = None, resolution: int = 9, min_count: int = 10):
     import duckdb
     from utils import duckdb_with_h3
     import shapely

--- a/public/DuckDB_NYC_Example/DuckDB_NYC_Example.py
+++ b/public/DuckDB_NYC_Example/DuckDB_NYC_Example.py
@@ -1,6 +1,6 @@
 # Note: This UDF is only for demo purposes. You may get `HTTP GET error` after several times calling it. This is the data retrieval issue caused by Cloudfront servers not responding.
 @fused.udf
-def udf(bbox=None, agg_factor=3, min_count=5):
+def udf(bbox: fused.types.TileGDF = None, agg_factor=3, min_count=5):
     import duckdb
 
     utils = fused.load(

--- a/public/HLS_Tile_Example/HLS_Tile_Example.py
+++ b/public/HLS_Tile_Example/HLS_Tile_Example.py
@@ -1,6 +1,6 @@
 @fused.udf
 def udf(
-    bbox,
+    bbox: fused.types.TileGDF,
     collection_id="HLSS30_2.0",  # Landsat:'HLSL30_2.0' & Sentinel:'HLSS30_2.0'
     band="B8A",  # Landsat:'B05' & Sentinel:'B8A'
     date_range="2023-10/2024-01",

--- a/public/NAIP_Tile_Example/NAIP_Tile_Example.py
+++ b/public/NAIP_Tile_Example/NAIP_Tile_Example.py
@@ -1,6 +1,6 @@
 @fused.udf
 def udf(
-    bbox,
+    bbox: fused.types.TileGDF,
     var="NDVI",
     chip_len: int=256,
     buffer_degree=0.000,

--- a/public/S2_explorer/S2_explorer.py
+++ b/public/S2_explorer/S2_explorer.py
@@ -1,5 +1,5 @@
 def udf(
-    bbox,
+    bbox: fused.types.TileGDF,
     provider="AWS",
     channels=["B11", "veg", "snow"],
     time_of_interest="2023-05-01/2023-09-13",

--- a/public/Solar_Induced_Fluorescence/Solar_Induced_Fluorescence.py
+++ b/public/Solar_Induced_Fluorescence/Solar_Induced_Fluorescence.py
@@ -1,5 +1,5 @@
 @fused.udf
-def udf(bbox, year: str = "2016", month: str = "07", period: str ="b", chip_len: int = 1024):
+def udf(bbox: fused.types.TileGDF, year: str = "2016", month: str = "07", period: str ="b", chip_len: int = 1024):
     xy_cols = ['lon', 'lat']
     from utils import get_masked_array, get_da, get_da_bounds, clip_arr
     import pandas as pd


### PR DESCRIPTION
updated any UDFs in /public containing bbox to have types `fused.types.TileGDF` or `fused.types.ViewportGDF`

- community left untouched, there are many UDFs in there without typed bbox