### PR TITLE
set proper default inputs for placekey udf to pass integration test

### DIFF
--- a/public/Create_A_Placekey_Join/Create_A_Placekey_Join.py
+++ b/public/Create_A_Placekey_Join/Create_A_Placekey_Join.py
@@ -1,7 +1,7 @@
 @fused.udf
 def udf(bbox: fused.types.TileGDF,
-        dataset1: str = 'dataset name here',
-        dataset2: str = 'dataset name here',
+        dataset1: str = 'home-health-agency-medicare-enrollments',
+        dataset2: str = 'national-provider-identifier',
         preview: bool=False):
     #import necessary things
     from utils import placekey_merge, get_placekeyd_dataset


### PR DESCRIPTION
incorrect placeholder strings were being used as the default values for the public `Create_A_Placekey_Join` udf causing integration tests to fail for it