### PR TITLE
update DEM_Tile_Example to use the max zoom level for resolution calc

### DIFF
--- a/public/DEM_Tile_Example/DEM_Tile_Example.py
+++ b/public/DEM_Tile_Example/DEM_Tile_Example.py
@@ -35,7 +35,7 @@ def udf(
     print(f"Returned {len(items)} Items")
 
     # Calculate the resolution based on zoom level.
-    resolution = int(20 * 2 ** (13 - bbox.z[0]))
+    resolution = int(20 * 2 ** (13 - min(bbox.z[0], 13)))
     print(f"{resolution=}")
 
     # Load the data into an XArray dataset


### PR DESCRIPTION
When zooming in more than a certain level, the UDF used to throw a `ValueError: Integers to negative integer powers are not allowed.`.

Since the default zoom value used in the integration tests is greater than the threshold used here, it always used to fail. This PR should fix that