### PR TITLE
initial testing utility for udfs

### DIFF
--- a/public/common/utils.py
+++ b/public/common/utils.py
@@ -2787,7 +2787,7 @@ def add_utm_area(gdf, utm_col='utm_epsg', utm_area_col='utm_area_sqm'):
     return gdf
 
 
-def run_submit_default(udf_token: str, cache_length: str = "9999d", default_params_token: Optional[str] = None):
+def run_submit_with_defaults(udf_token: str, cache_length: str = "9999d", default_params_token: Optional[str] = None):
     """
     Uses fused.submit() to run a UDF over:
     - A UDF that returns a pd.DataFrame of test arguments (`default_params_token`)
@@ -2839,8 +2839,8 @@ def test_udf(udf_token: str, cache_length: str = "9999d", arg_token: Optional[st
     """
     import pickle
 
-    cached_run = run_submit_default(udf_token, cache_length, arg_token)
-    current_run = run_submit_default(udf_token, "0s", arg_token)
+    cached_run = run_submit_with_defaults(udf_token, cache_length, arg_token)
+    current_run = run_submit_with_defaults(udf_token, "0s", arg_token)
 
     # Check if results are valid
     all_passing = (current_run["status"] == "success").all()

--- a/public/common/utils.py
+++ b/public/common/utils.py
@@ -2780,7 +2780,7 @@ def add_utm_area(gdf, utm_col='utm_epsg', utm_area_col='utm_area_sqm'):
     return gdf
 
 
-def test_udf(udf_token: str, cache_length: str = "1d", arg_token: Optional[str] = None):
+def test_udf(udf_token: str, cache_length: str = "9999d", arg_token: Optional[str] = None):
     """
     Test a UDF by running it with the provided arguments and comparing results with cached output.
 
@@ -2794,7 +2794,7 @@ def test_udf(udf_token: str, cache_length: str = "1d", arg_token: Optional[str] 
 
     Args:
         udf_token: The identifier string of the UDF to test
-        cache_length: The length of time to cache the results (default: 1d)
+        cache_length: The length of time to cache the results (default: 9999d)
         arg_token: Optional token of a UDF that returns custom arguments as pd.DataFrame
 
     Returns:

--- a/public/common/utils.py
+++ b/public/common/utils.py
@@ -2806,6 +2806,7 @@ def test_udf(udf_token: str, cache_length: str = "1d", arg_token: Optional[str] 
     """
     import mercantile
     import math
+    import pickle
 
     udf = fused.load(udf_token)
     arg_list: list[dict[str, Any]] = []
@@ -2836,18 +2837,16 @@ def test_udf(udf_token: str, cache_length: str = "1d", arg_token: Optional[str] 
     if not arg_list:
         raise ValueError("No arguments found for UDF")
 
-    current_run = fused.submit(udf_token, arg_list, cache_max_age="0s", wait_on_results=True)
     prev_run = fused.submit(
         udf_token,
         arg_list,
         cache_max_age=cache_length,
         wait_on_results=True,
     )
+    current_run = fused.submit(udf_token, arg_list, cache_max_age="0s", wait_on_results=True)
+
     # Check if results are valid
     all_passing = all(not isinstance(res, Exception) for res in current_run["result"])
-    # Compare each dataframe in the result column
-    all_equal = all(
-        isinstance(old_df, pd.DataFrame) and old_df.equals(new_df)
-        for old_df, new_df in zip(prev_run["result"], current_run["result"])
-    )
+    # Check if result matches cached result
+    all_equal = pickle.dumps(prev_run) == pickle.dumps(current_run)
     return (all_passing, all_equal, prev_run, current_run)

--- a/public/common/utils.py
+++ b/public/common/utils.py
@@ -2787,19 +2787,20 @@ def add_utm_area(gdf, utm_col='utm_epsg', utm_area_col='utm_area_sqm'):
     return gdf
 
 
-def run_submit_default(udf_token: str, cache_length: str = "9999d", arg_token: Optional[str] = None):
+def run_submit_default(udf_token: str, cache_length: str = "9999d", default_params_token: Optional[str] = None):
     """
     Uses fused.submit() to run a UDF over:
-    - A UDF that returns a pd.DataFrame of test arguments (`arg_token`)
+    - A UDF that returns a pd.DataFrame of test arguments (`default_params_token`)
     - Or default params (expectes udf.utils.submit_default_params to return a pd.DataFrame)
     """
     
     # Assume people know what they're doing 
     try:
         # arg_token is a UDF that returns a pd.DataFrame of test arguments
-        arg_list = fused.run(arg_token)
+        arg_list = fused.run(default_params_token)
+        print(f"Loaded default params from UDF {default_params_token}... Running UDF over these")
     except Exception as e:
-        print(f"Couldn't load UDF {udf_token} with arg_token {arg_token}, trying to load default params...")
+        print(f"Couldn't load UDF {udf_token} with arg_token {default_params_token}, trying to load default params...")
         
         try:
             udf = fused.load(udf_token)
@@ -2842,7 +2843,7 @@ def test_udf(udf_token: str, cache_length: str = "9999d", arg_token: Optional[st
     current_run = run_submit_default(udf_token, "0s", arg_token)
 
     # Check if results are valid
-    all_passing = bool((current_run["status"] == "success").all())
+    all_passing = (current_run["status"] == "success").all()
     # Check if result matches cached result
     all_equal = pickle.dumps(cached_run) == pickle.dumps(current_run)
-    return (all_passing, all_equal, cached_run, current_run)
+    return (bool(all_passing), all_equal, cached_run, current_run)

--- a/public/common/utils.py
+++ b/public/common/utils.py
@@ -2846,7 +2846,7 @@ def test_udf(udf_token: str, cache_length: str = "1d", arg_token: Optional[str] 
     current_run = fused.submit(udf_token, arg_list, cache_max_age="0s", wait_on_results=True)
 
     # Check if results are valid
-    all_passing = all(not isinstance(res, Exception) for res in current_run["result"])
+    all_passing = (current_run["status"] == "success").all()
     # Check if result matches cached result
     all_equal = pickle.dumps(prev_run) == pickle.dumps(current_run)
     return (all_passing, all_equal, prev_run, current_run)

--- a/public/common/utils.py
+++ b/public/common/utils.py
@@ -2798,6 +2798,12 @@ def run_submit_with_defaults(udf_token: str, cache_length: str = "9999d", defaul
     try:
         # arg_token is a UDF that returns a pd.DataFrame of test arguments
         arg_list = fused.run(default_params_token)
+
+        if 'bounds' in arg_list.columns:
+            # This is a hacky workaround for now as we can't pass np.float bounds to `fused.run(udf, bounds) so need to convert them to float
+            # but fused.run() returns bounds as `np.float` for whatever reason
+            arg_list['bounds'] = arg_list['bounds'].apply(lambda bounds_list: [float(x) for x in bounds_list])
+            
         print(f"Loaded default params from UDF {default_params_token}... Running UDF over these")
     except Exception as e:
         print(f"Couldn't load UDF {udf_token} with arg_token {default_params_token}, trying to load default params...")


### PR DESCRIPTION
Create testing utility which supports getting input params from:
- a separate UDF (using `arg_token`)
- `get_test_params` method defined in the utils module of UDF
- default view state params (metadata) of the UDF