### PR TITLE
fix type error due to stale pinned version

### DIFF
--- a/public/DC_AOI_Example/utils.py
+++ b/public/DC_AOI_Example/utils.py
@@ -15,7 +15,7 @@ def get_arr(
     max_items=30
 ):
 
-    greenest_example_utils = fused.load('https://github.com/fusedio/udfs/tree/9bfb5d0/public/Satellite_Greenest_Pixel').utils
+    greenest_example_utils = fused.load('https://github.com/fusedio/udfs/tree/e74035a/public/Satellite_Greenest_Pixel').utils
 
     stac_items = greenest_example_utils.search_pc_catalog(
         bounds=bounds,


### PR DESCRIPTION
The bbox -> bounds change wasn't being reflected in the old pinned utils version, causing `DC_AOI_EXAMPLE` to fail