### PR TITLE
don't convert bounds back to tile

### DIFF
--- a/public/DuckDB_H3_Example_Tile/DuckDB_H3_Example_Tile.py
+++ b/public/DuckDB_H3_Example_Tile/DuckDB_H3_Example_Tile.py
@@ -1,37 +1,20 @@
 @fused.udf
-def udf(bounds: fused.types.Bounds=None, resolution: int = 11, min_count: int = 10):
+def udf(bounds: fused.types.Bounds = None, resolution: int = 11, min_count: int = 10):
     import duckdb
     import shapely
     import geopandas as gpd
 
-    # convert bounds to tile
-    common_utils = fused.load("https://github.com/fusedio/udfs/tree/bb712a5/public/common/").utils
-    zoom = common_utils.estimate_zoom(bounds)
-    tile = common_utils.get_tiles(bounds, zoom=zoom)
-
-
-    tile_bounds_gdf = gpd.GeoDataFrame.from_features({"type":"FeatureCollection","features":[{"type":"Feature","properties":{"shape":"Rectangle"},"geometry":{"type":"Polygon","coordinates":[[[-73.99322955922597,40.76627870054801],[-73.96753345042097,40.76627870054801],[-73.96753345042097,40.74825844008337],[-73.99322955922597,40.74825844008337],[-73.99322955922597,40.76627870054801]]]}}]})
-    default_bounds = tile_bounds_gdf.iloc[0].geometry
-    tile_bounds_geom = tile if tile is not None else default_bounds
-
-    tile = tile.bounds.values[0] if tile is not None else default_bounds.bounds
-    print(tile)
-
-    utils = fused.load(
-        "https://github.com/fusedio/udfs/tree/f928ee1/public/common/"
-    ).utils
-    h3_utils = fused.load(
-        "https://github.com/fusedio/udfs/tree/870e162/public/DuckDB_H3_Example/"
-    ).utils
+    utils = fused.load("https://github.com/fusedio/udfs/tree/f928ee1/public/common/").utils
+    h3_utils = fused.load("https://github.com/fusedio/udfs/tree/870e162/public/DuckDB_H3_Example/").utils
     con = duckdb.connect()
 
     h3_utils.load_h3_duckdb(con)
     con.sql(f"""INSTALL httpfs; LOAD httpfs;""")
-    
+
     @fused.cache
     def read_data(url, resolution, min_count, bounds):
         xmin, ymin, xmax, ymax = bounds
-        
+
         query = """
         SELECT h3_h3_to_string(h3_latlng_to_cell(pickup_latitude, pickup_longitude, $resolution)) cell_id,
                h3_cell_to_boundary_wkt(cell_id) boundary,
@@ -48,17 +31,27 @@ def udf(bounds: fused.types.Bounds=None, resolution: int = 11, min_count: int = 
         """
         print(query)
 
-        df = con.sql(query, params={'url': url, 'xmin': xmin, 'xmax': xmax, 'ymin': ymin, "ymax": ymax, 'min_count': min_count, 'resolution': resolution}).df()
+        df = con.sql(
+            query,
+            params={
+                "url": url,
+                "xmin": xmin,
+                "xmax": xmax,
+                "ymin": ymin,
+                "ymax": ymax,
+                "min_count": min_count,
+                "resolution": resolution,
+            },
+        ).df()
         return df
 
-
     df = read_data(
-        url='s3://fused-asset/misc/nyc/tlc/trip-data/yellow_tripdata_2010-01.parquet', 
-        resolution=resolution, 
-        min_count=min_count, 
-        bounds=tile
+        url="s3://fused-asset/misc/nyc/tlc/trip-data/yellow_tripdata_2010-01.parquet",
+        resolution=resolution,
+        min_count=min_count,
+        bounds=bounds,
     )
     print("number of trips:", df.cnt.sum())
-    gdf = gpd.GeoDataFrame(df.drop(columns=['boundary']), geometry=df.boundary.apply(shapely.wkt.loads))
+    gdf = gpd.GeoDataFrame(df.drop(columns=["boundary"]), geometry=df.boundary.apply(shapely.wkt.loads))
     print(gdf)
     return gdf

--- a/public/DuckDB_H3_Example_Tile/README.MD
+++ b/public/DuckDB_H3_Example_Tile/README.MD
@@ -1,9 +1,6 @@
 <!--fused:preview-->
 <p align="center"><img src="https://fused-magic.s3.us-west-2.amazonaws.com/thumbnails/udfs-staging/DuckDB_H3_Example_Tile.png" width="600" alt="UDF preview image"></p>
 
-<!--fused:tags-->
-Tags:  `Aggregation` `parquet` `DuckDB` `Fused` `H3-vector`
-
 <!--fused:readme-->
 ## Overview
 

--- a/public/DuckDB_H3_Example_Tile/meta.json
+++ b/public/DuckDB_H3_Example_Tile/meta.json
@@ -12,30 +12,6 @@
           "entrypoint": "udf",
           "parameters": {},
           "metadata": {
-            "fused:assetUrl": "https://fused-magic.s3.us-west-2.amazonaws.com/thumbnails/udfs-staging/Duckdb_H3_Example.png",
-            "fused:tags": [
-              {
-                "id": "Aggregation",
-                "label": "Aggregation"
-              },
-              {
-                "id": "parquet",
-                "label": "parquet"
-              },
-              {
-                "id": "DuckDB",
-                "label": "DuckDB"
-              },
-              {
-                "id": "Fused",
-                "label": "Fused"
-              },
-              {
-                "id": "H3-vector",
-                "label": "H3-vector"
-              }
-            ],
-            "fused:description": "## Overview\n\nThis UDF shows how to open NYC yellow taxi trip dataset using DuckDB and aggregate the pickups using [H3-DuckDB](https://github.com/isaacbrodsky/h3-duckdb) as tiles.\n\n## External links\n\n- [TLC Trip Record Data](https://www.nyc.gov/site/tlc/about/tlc-trip-record-data.page)\n\n## Run this in any Jupyter Notebook\n\n```python\nimport fused\n\nudf = fused.load(\"https://github.com/fusedio/udfs/tree/main/public/DuckDB_H3_Example_Tile\")\ngdf = fused.run(udf=udf, x=2412, y=3078, z=13)\ngdf\n```\n",
             "fused:vizConfig": {
               "tileLayer": {
                 "@@type": "TileLayer",
@@ -58,7 +34,7 @@
                 "getFillColor": "@@=[properties.cnt/3+200, properties.cnt/5+50, properties.cnt/20]"
               }
             },
-            "fused:udfType": "auto",
+            "fused:udfType": "vector_tile",
             "fused:slug": "DuckDB_H3_Example_Tile",
             "fused:name": "DuckDB_H3_Example_Tile",
             "fused:id": null,
@@ -70,23 +46,39 @@
               "pitch": 0,
               "bearing": 0
             },
-            "fused:gitUrl": "https://github.com/fusedio/udfs/tree/bbd1171cfa023b0b67950f98de05eb60d1a758aa/public/DuckDB_H3_Example/",
-            "fused:gitShortUrl": "https://github.com/fusedio/udfs/tree/bbd1171/public/DuckDB_H3_Example/",
-            "fused:gitPath": "public/DuckDB_H3_Example",
-            "fused:gitRef": "bbd1171cfa023b0b67950f98de05eb60d1a758aa",
+            "fused:gitUrl": "https://github.com/fusedio/udfs/tree/495e84eda5e4ff7d7e5db949bdb562d154630887/public/DuckDB_H3_Example_Tile/",
+            "fused:gitShortUrl": "https://github.com/fusedio/udfs/tree/495e84e/public/DuckDB_H3_Example_Tile/",
+            "fused:gitPath": "public/DuckDB_H3_Example_Tile",
+            "fused:gitRef": "495e84eda5e4ff7d7e5db949bdb562d154630887",
             "fused:gitAuthorNames": [
-              "Isaac Brodsky"
+              "Isaac Brodsky",
+              "Plinio Guzman",
+              "Suryashankar Das",
+              "Milind Soni"
             ],
             "fused:gitAuthorUsernames": [
-              "isaacbrodsky"
+              "isaacbrodsky",
+              "pgzmnk",
+              "iamsdas",
+              "milind-soni"
             ],
             "fused:gitAuthorUrls": [
-              "https://github.com/isaacbrodsky"
+              "https://github.com/isaacbrodsky",
+              "https://github.com/pgzmnk",
+              "https://github.com/iamsdas",
+              "https://github.com/milind-soni"
             ],
             "fused:gitAuthorAvatarUrls": [
-              "https://avatars.githubusercontent.com/u/9139378?v=4"
+              "https://avatars.githubusercontent.com/u/9139378?v=4",
+              "https://avatars.githubusercontent.com/u/27398253?v=4",
+              "https://avatars.githubusercontent.com/u/26461855?v=4",
+              "https://avatars.githubusercontent.com/u/46266943?v=4"
             ],
-            "fused:gitLastModified": "2024-04-03T20:54:55+00:00"
+            "fused:gitLastModified": "2025-03-28T10:29:14+00:00",
+            "fused:assetUrl": "https://fused-magic.s3.us-west-2.amazonaws.com/thumbnails/udfs-staging/DuckDB_H3_Example_Tile.png",
+            "fused:description": "## Overview\n\nThis UDF shows how to open NYC yellow taxi trip dataset using DuckDB and aggregate the pickups using [H3-DuckDB](https://github.com/isaacbrodsky/h3-duckdb) as tiles.\n\n## External links\n\n- [TLC Trip Record Data](https://www.nyc.gov/site/tlc/about/tlc-trip-record-data.page)\n\n## Run this in any Jupyter Notebook\n\n```python\nimport fused\n\nudf = fused.load(\"https://github.com/fusedio/udfs/tree/main/public/DuckDB_H3_Example_Tile\")\ngdf = fused.run(udf=udf, x=2412, y=3078, z=13)\ngdf\n```\n",
+            "fused:explorerTab": "public",
+            "fused:gitRepo": "fusedio/udfs"
           },
           "source": "DuckDB_H3_Example_Tile.py",
           "headers": []


### PR DESCRIPTION
don't convert bounds back to tile

If converting bounds back to tile, the UDF bounds look odd when run in Workbench as a Viewport UDF. This way it looks OK as either Viewport UDF or Tile UDF.

Made in [Fused Workbench](https://www.fused.io/workbench)