### PR TITLE
Hexagonify raster from URL 

Used for documenting raster to Hex docs ...

### DIFF
--- a/public/Hexagonify_raster_from_url/Hexagonify_raster_from_url.py
+++ b/public/Hexagonify_raster_from_url/Hexagonify_raster_from_url.py
@@ -1,0 +1,38 @@
+@fused.udf
+def udf(raster_path = 'https://s3.amazonaws.com/elevation-tiles-prod/geotiff/4/4/6.tif', 
+        stats_type="mean", 
+        h3_res: int = 4,
+        height_scale: int = 10,
+         color_scale:float=1
+    ):
+
+
+@fused.cache
+def df_to_hex(df, res, latlng_cols=("lat", "lng")):
+    utils = fused.load(
+        "https://github.com/fusedio/udfs/tree/be3bc93/public/common/"
+    ).utils
+    qr = f"""
+            SELECT h3_latlng_to_cell({latlng_cols[0]}, {latlng_cols[1]}, {res}) AS hex, ARRAY_AGG(data) as agg_data
+            FROM df
+            group by 1
+          --  order by 1
+        """
+    con = utils.duckdb_connect()
+    return con.query(qr).df()
+
+
+@fused.cache
+def aggregate_df_hex(df, res, latlng_cols=("lat", "lng"), stats_type="mean"):
+    import pandas as pd
+
+    df = df_to_hex(df, res=res, latlng_cols=latlng_cols)
+    if stats_type == "sum":
+        fn = lambda x: pd.Series(x).sum()
+    elif stats_type == "mean":
+        fn = lambda x: pd.Series(x).mean()
+    else:
+        fn = lambda x: pd.Series(x).mean()
+    df["metric"] = df.agg_data.map(fn)
+    return df
+

--- a/public/Hexagonify_raster_from_url/README.MD
+++ b/public/Hexagonify_raster_from_url/README.MD
@@ -1,0 +1,3 @@
+<!--fused:readme-->
+Exported from Fused UDF Workbench
+

--- a/public/Hexagonify_raster_from_url/meta.json
+++ b/public/Hexagonify_raster_from_url/meta.json
@@ -20,6 +20,28 @@
               "pitch": 0,
               "bearing": 0
             },
+            "fused:name": "Hexagonify_raster_from_url",
+            "fused:slug": "Hexagonify_raster_from_url",
+            "fused:gitRepo": "fusedio/udfs",
+            "fused:gitRef": "026421b362ae5b37a446754fb242bb93aacc873a",
+            "fused:gitUrl": "https://github.com/fusedio/udfs/tree/026421b362ae5b37a446754fb242bb93aacc873a/public/Hexagonify_raster_from_url/",
+            "fused:gitShortUrl": "https://github.com/fusedio/udfs/tree/026421b/public/Hexagonify_raster_from_url/",
+            "fused:gitPath": "public/Hexagonify_raster_from_url",
+            "fused:gitLastModified": "2025-04-25T18:16:07.493Z",
+            "fused:gitHistory": [
+              {
+                "fused:defaultViewState": {
+                  "enable": true,
+                  "latitude": 34.57648672753711,
+                  "longitude": -80.33884456894795,
+                  "zoom": 4.141573809520789,
+                  "pitch": 0,
+                  "bearing": 0
+                }
+              }
+            ],
+            "fused:gitPullRequestBranch": "max-patch-f277f8-Hexagonify-raster-from-URL-Used-f",
+            "fused:gitPullRequestLink": "https://github.com/fusedio/udfs/pull/855",
             "fused:vizConfig": {
               "tileLayer": {
                 "@@type": "TileLayer",
@@ -75,8 +97,6 @@
               }
             },
             "fused:udfType": "auto",
-            "fused:slug": "Hexagonify_raster_from_url",
-            "fused:name": "Hexagonify_raster_from_url",
             "fused:id": null
           },
           "source": "Hexagonify_raster_from_url.py",

--- a/public/Hexagonify_raster_from_url/meta.json
+++ b/public/Hexagonify_raster_from_url/meta.json
@@ -1,0 +1,89 @@
+{
+  "version": "0.0.3",
+  "job_config": {
+    "version": "0.0.3",
+    "name": null,
+    "steps": [
+      {
+        "type": "udf",
+        "udf": {
+          "type": "geopandas_v2",
+          "name": "Hexagonify_raster_from_url",
+          "entrypoint": "udf",
+          "parameters": {},
+          "metadata": {
+            "fused:defaultViewState": {
+              "enable": true,
+              "latitude": 34.57648672753711,
+              "longitude": -80.33884456894795,
+              "zoom": 4.141573809520789,
+              "pitch": 0,
+              "bearing": 0
+            },
+            "fused:vizConfig": {
+              "tileLayer": {
+                "@@type": "TileLayer",
+                "minZoom": 0,
+                "maxZoom": 14,
+                "tileSize": 256,
+                "extrude": true,
+                "pickable": true
+              },
+              "rasterLayer": {
+                "@@type": "BitmapLayer",
+                "pickable": true
+              },
+              "vectorLayer": {
+                "@@type": "GeoJsonLayer",
+                "stroked": true,
+                "filled": false,
+                "pickable": true,
+                "lineWidthMinPixels": 1,
+                "pointRadiusMinPixels": 1,
+                "getLineColor": {
+                  "@@function": "colorContinuous",
+                  "attr": "value",
+                  "domain": [
+                    0,
+                    10
+                  ],
+                  "steps": 20,
+                  "colors": "PinkYl",
+                  "nullColor": [
+                    184,
+                    184,
+                    184
+                  ]
+                },
+                "getFillColor": [
+                  208,
+                  208,
+                  208,
+                  40
+                ]
+              },
+              "hexLayer": {
+                "opacity": 1,
+                "@@type": "H3HexagonLayer",
+                "stroked": true,
+                "filled": true,
+                "pickable": true,
+                "getHexagon": "@@=properties.hex",
+                "getFillColor": "@@=[properties.metric*1, properties.metric*0.3, properties.metric*0.1]",
+                "getElevation": "@@=properties.metric",
+                "elevationScale": 20
+              }
+            },
+            "fused:udfType": "auto",
+            "fused:slug": "Hexagonify_raster_from_url",
+            "fused:name": "Hexagonify_raster_from_url",
+            "fused:id": null
+          },
+          "source": "Hexagonify_raster_from_url.py",
+          "headers": []
+        }
+      }
+    ],
+    "metadata": null
+  }
+}


### PR DESCRIPTION
Hexagonify raster from URL 

Used for documenting raster to Hex docs purposes 

Made in [Fused Workbench](https://www.fused.io/workbench)