### PR TITLE
fix FEMA_Buildings_US default to udf type tile instead of auto

### DIFF
--- a/public/FEMA_Buildings_US/meta.json
+++ b/public/FEMA_Buildings_US/meta.json
@@ -47,7 +47,7 @@
                 }
               }
             },
-            "fused:udfType": "auto",
+            "fused:udfType": "vector_tile",
             "fused:slug": "FEMA_Buildings_US",
             "fused:name": "FEMA_Buildings_US",
             "fused:id": null,


### PR DESCRIPTION
https://www.notion.so/fusedio/FEMA_Buildings_US-I-have-to-zoom-in-very-far-for-data-to-show-up-1e4899d3b76380c19d0cff4f28650037?pvs=4

The buildings are visible in tile mode since each tile has smaller bounding boxes than when in viewport mode