### PR TITLE
fix tests by using exact geopandas version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       #----------------------------------------------
       - name: Install dependencies
         shell: bash
-        run: pip install fused[batch] pytest openpyxl duckdb fiona scipy
+        run: pip install fused[batch] pytest openpyxl duckdb fiona scipy geopandas==0.14.4
 
       #----------------------------------------------
       #       run tests for files udfs


### PR DESCRIPTION
Seems like the version range specified in fused-py for geopandas is too broad. It works fine in the fused-py repo since it uses a `poetry.lock` file. This is not the case when we are installing fused-py as a package it seems.