### PR TITLE
feat: only run tests on UDFs that have been changed in the PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,9 +32,24 @@ jobs:
         run: pip install fused[batch] pytest openpyxl duckdb fiona scipy
 
       #----------------------------------------------
+      #       get all changed UDFs
+      #----------------------------------------------
+      - name: Get all changed UDFs
+        id: changed-udfs
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
+        with:
+          separator: ","
+          files_yaml: |
+            public:
+              - public/**
+            files:
+              - files/**
+
+      #----------------------------------------------
       #       run tests for files udfs
       #----------------------------------------------
       - name: Run tests for files udfs
+        if: steps.changed-udfs.outputs.files_any_changed == 'true'
         shell: bash
         env:
           AUTH0_REFRESH_TOKEN: ${{ secrets.AUTH0_REFRESH_TOKEN }}
@@ -44,10 +59,12 @@ jobs:
       #       run tests for public udfs
       #----------------------------------------------
       - name: Run tests for public udfs
+        if: steps.changed-udfs.outputs.public_any_changed == 'true'
         env:
           GITHUB_SHA: ${{ github.event.pull_request.head.sha }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AUTH0_REFRESH_TOKEN: ${{ secrets.AUTH0_REFRESH_TOKEN }}
+          CHANGED_FILES: ${{ steps.changed-udfs.outputs.public_all_changed_files }}
         shell: bash
         run: pytest tests/test_public_udfs.py --tb=short
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
         shell: bash
         env:
           AUTH0_REFRESH_TOKEN: ${{ secrets.AUTH0_REFRESH_TOKEN }}
-        run: pytest tests/test_file_udfs.py -v -s --tb=short
+        run: pytest tests/test_file_udfs.py --tb=short
 
       #----------------------------------------------
       #       run tests for public udfs
@@ -66,6 +66,6 @@ jobs:
           AUTH0_REFRESH_TOKEN: ${{ secrets.AUTH0_REFRESH_TOKEN }}
           CHANGED_FILES: ${{ steps.changed-udfs.outputs.public_all_changed_files }}
         shell: bash
-        run: pytest tests/test_public_udfs.py -v -s --tb=short
+        run: pytest tests/test_public_udfs.py --tb=short
 
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
         shell: bash
         env:
           AUTH0_REFRESH_TOKEN: ${{ secrets.AUTH0_REFRESH_TOKEN }}
-        run: pytest tests/test_file_udfs.py --tb=short
+        run: pytest tests/test_file_udfs.py -v -s --tb=short
 
       #----------------------------------------------
       #       run tests for public udfs
@@ -66,6 +66,6 @@ jobs:
           AUTH0_REFRESH_TOKEN: ${{ secrets.AUTH0_REFRESH_TOKEN }}
           CHANGED_FILES: ${{ steps.changed-udfs.outputs.public_all_changed_files }}
         shell: bash
-        run: pytest tests/test_public_udfs.py --tb=short
+        run: pytest tests/test_public_udfs.py -v -s --tb=short
 
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,7 @@ jobs:
       #----------------------------------------------
       - name: Get all changed UDFs
         id: changed-udfs
+        if: github.event_name == 'pull_request'
         uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
         with:
           separator: ","
@@ -49,7 +50,7 @@ jobs:
       #       run tests for files udfs
       #----------------------------------------------
       - name: Run tests for files udfs
-        if: steps.changed-udfs.outputs.files_any_changed == 'true'
+        if: github.event_name == 'push' || steps.changed-udfs.outputs.files_any_changed == 'true'
         shell: bash
         env:
           AUTH0_REFRESH_TOKEN: ${{ secrets.AUTH0_REFRESH_TOKEN }}
@@ -59,10 +60,8 @@ jobs:
       #       run tests for public udfs
       #----------------------------------------------
       - name: Run tests for public udfs
-        if: steps.changed-udfs.outputs.public_any_changed == 'true'
+        if: github.event_name == 'push' || steps.changed-udfs.outputs.public_any_changed == 'true'
         env:
-          GITHUB_SHA: ${{ github.event.pull_request.head.sha }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AUTH0_REFRESH_TOKEN: ${{ secrets.AUTH0_REFRESH_TOKEN }}
           CHANGED_FILES: ${{ steps.changed-udfs.outputs.public_all_changed_files }}
         shell: bash

--- a/files/GeoPandas_ZIP/GeoPandas_ZIP.py
+++ b/files/GeoPandas_ZIP/GeoPandas_ZIP.py
@@ -6,6 +6,7 @@ def udf(path: str, preview: bool=False):
     # path = f"zip+{path}"
     gdf = gpd.read_file(path)
     print(gdf)
+
     if preview:
         return gdf.geometry
     return gdf

--- a/public/Boston_Bikes_Example/BostonBlueBikes.py
+++ b/public/Boston_Bikes_Example/BostonBlueBikes.py
@@ -4,7 +4,7 @@ def udf():
     import requests
     import pytz
     from datetime import datetime
-    
+
     geo_json_data = {
        "type": "FeatureCollection",
        "features": []
@@ -23,7 +23,7 @@ def udf():
                 station['lat']]
     for status in stations_status['data']['stations']:
         unixts = int(status['last_reported'])
-        
+
         ts = datetime.fromtimestamp(unixts, pytz.timezone('America/New_York')).strftime('%Y-%m-%d %H:%M:%S')
         if status['station_id'] in stations_dict:
             r,g,b = [100,100,100]

--- a/public/Fire_Proximity_Buffer/Fire_Proximity_Buffer.py
+++ b/public/Fire_Proximity_Buffer/Fire_Proximity_Buffer.py
@@ -1,6 +1,6 @@
 @fused.udf
 def udf(
-    bounds: fused.types.Bounds=[-117.644,34.416,-117.639,34.421],
+    bounds: fused.types.Bounds=[-117.644, 34.416, -117.639, 34.421],
     date_start: int = 2,
 ):
 

--- a/tests/test_public_udfs.py
+++ b/tests/test_public_udfs.py
@@ -64,7 +64,6 @@ def get_changed_udfs() -> list[str] | None:
     If the environment variable is not set, return None
     """
     files = os.environ.get("CHANGED_FILES")
-    print(f"Changed files: {files}")
     if files:
         file_names = files.split(",")
         # public/UDF_NAME/UDF_NAME.py

--- a/tests/test_public_udfs.py
+++ b/tests/test_public_udfs.py
@@ -39,6 +39,7 @@ def get_public_udf_folders():
     """
     Get the list of public UDF folders from the local repo as pytest params.
     """
+    changed_udfs = get_changed_udfs()
 
     for item in os.listdir(PUBLIC_UDFS_PATH):
         folder_abs_path = os.path.join(PUBLIC_UDFS_PATH, item)
@@ -47,10 +48,28 @@ def get_public_udf_folders():
                 item,
                 folder_abs_path,
                 id=item,
-                marks=pytest.mark.skipif(
+                marks=[pytest.mark.skipif(
                     item in UDFS_THAT_ERROR, reason="UDF is not working"
                 ),
+                pytest.mark.skipif(
+                    changed_udfs is not None and item not in changed_udfs,
+                    reason="UDF is not changed",
+                ),
+            ]
             )
+
+def get_changed_udfs() -> list[str] | None:
+    """
+    Get the list of changed UDFs from the environment variable CHANGED_FILES
+    If the environment variable is not set, return None
+    """
+    files = os.environ.get("CHANGED_FILES")
+    print(f"Changed files: {files}")
+    if files:
+        file_names = files.split(",")
+        folders = [file.rsplit("/", 1)[0] for file in file_names]
+        return folders
+    return None
 
 
 def get_bbox_for_udf(metadata: dict[str, Any]):

--- a/tests/test_public_udfs.py
+++ b/tests/test_public_udfs.py
@@ -67,8 +67,9 @@ def get_changed_udfs() -> list[str] | None:
     print(f"Changed files: {files}")
     if files:
         file_names = files.split(",")
-        folders = [file.rsplit("/", 1)[0] for file in file_names]
-        return folders
+        # public/UDF_NAME/UDF_NAME.py
+        udf = [file.split("/", 2)[1] for file in file_names]
+        return udf
     return None
 
 


### PR DESCRIPTION
Note:
- This is assuming all internal fused.load calls in the UDFs are using a pinned version and not the latest.
- We won't be running the tests for all the UDFs in the UDFs repo anymore