### PR TITLE
remove manual menu order override for join_with_overture udf

### DIFF
--- a/files/Join_with_Overture/README.MD
+++ b/files/Join_with_Overture/README.MD
@@ -4,7 +4,6 @@
 
 <!--fused:filePreview-->
 Extensions: `parquet` `pq` `gpq` `geoparquet` `json` `geojson` `zip`
-Menu order: 3
 
 <!--fused:readme-->
 Read a Parquet or Geoparquet file and join with Overture.


### PR DESCRIPTION
We don't seem to be overriding the menu order of any other UDF, causing this UDF to always appear on top.