### PR TITLE
Refactor UDF imports and standardize common utils naming

### DIFF
--- a/community/K_Njoroge/Flood_Risk_Analysis_v2/utils.py
+++ b/community/K_Njoroge/Flood_Risk_Analysis_v2/utils.py
@@ -4,7 +4,7 @@ import numpy as np
 
 read_tiff = fused.load(
     "https://github.com/fusedio/udfs/tree/3c4bc47/public/common/"
-).utils.read_tiff
+).common.read_tiff
 mosaic_tiff = fused.load(
     "https://github.com/fusedio/udfs/tree/3c4bc47/public/common/"
 ).utils.mosaic_tiff
@@ -90,7 +90,11 @@ def get_overture(
     import pandas as pd
     from shapely.geometry import box, shape
 
-    utils = fused.load("https://github.com/fusedio/udfs/tree/main/public/common/").utils
+    common = fused.load(
+
+    "https://github.com/fusedio/udfs/tree/3c4bc47/public/common/"
+
+    ).utils
 
     if release == "2024-02-15-alpha-0":
         if overture_type == "administrative_boundary":
@@ -156,7 +160,7 @@ def get_overture(
     def get_part(part):
         part_path = f"{table_path}/part={part}/" if num_parts != 1 else table_path
         try:
-            return utils.table_to_tile(
+            return common.table_to_tile(
                 bbox, table=part_path, use_columns=use_columns, min_zoom=min_zoom
             )
         except ValueError:

--- a/community/K_Njoroge/LA_Parking_meter_occupancy/utils.py
+++ b/community/K_Njoroge/LA_Parking_meter_occupancy/utils.py
@@ -17,8 +17,10 @@ def get_overture(
     import geopandas as gpd
     from shapely.geometry import shape, box
 
-    utils = fused.load(
-        "https://github.com/fusedio/udfs/tree/main/public/common/"
+    common = fused.load(
+
+    "https://github.com/fusedio/udfs/tree/main/public/common/"
+
     ).utils
 
     #if polygon is not None:
@@ -88,7 +90,7 @@ def get_overture(
     def get_part(part):
         part_path = f"{table_path}/part={part}/" if num_parts != 1 else table_path
         try:
-            return utils.table_to_tile(
+            return common.table_to_tile(
                 bbox, table=part_path, use_columns=use_columns, min_zoom=min_zoom
             )
         except ValueError:

--- a/community/fhk/CloudKitchens/CloudKitchens.py
+++ b/community/fhk/CloudKitchens/CloudKitchens.py
@@ -1,12 +1,11 @@
-import pandas as pd
-
 @fused.udf
 def udf(locations: pd.DataFrame = None, h3_res: int = 11, distance: int = 10):
+    import pandas as pd
     import json
     import geopandas as gpd
     import shapely
     from shapely.geometry import Polygon, MultiPolygon
-    utils = fused.load(
+    common = fused.load(
     "https://github.com/fusedio/udfs/tree/f8f0c0f/public/common/"
     ).utils
 

--- a/community/fhk/data_center_location_model/Data_Center_Location_Model.py
+++ b/community/fhk/data_center_location_model/Data_Center_Location_Model.py
@@ -1,16 +1,11 @@
 # Note: This UDF is only for demo purposes. You may get `HTTP GET error` after several times calling it. This is the data retrieval issue caused by Cloudfront servers not responding.
-from geopy.geocoders import Nominatim
 
-import geopandas as gpd
-import h3
 
-import highspy
-import numpy as np
-import networkx as nx
     
 
 @fused.cache
 def add_lat_lon(df):
+from geopy.geocoders import Nominatim
     geolocator = Nominatim(user_agent="fused")
     df['location'] = df.apply(lambda x: geolocator.geocode(x.city), axis=1)
 
@@ -20,6 +15,7 @@ def add_lat_lon(df):
     return df
 
 @fused.cache
+import h3
 def get_h3s():
     usa = gpd.read_file('https://raw.githubusercontent.com/scdoshi/us-geojson/master/geojson/nation/US.geojson')
     polygons = list(list(x.geoms) for x in usa.geometry)[0]
@@ -42,6 +38,7 @@ def int_var_dict(h, var_str, name, variable_index_count=0, lb=0, ub=1):
 
 
 def formulation(h, graph):
+import highspy
     inf = highspy.kHighsInf
     tasks = {j: f'{j}' for j in graph.nodes() if graph.out_degree[j] == 0}
     print(f'{len(tasks)} demand locations')
@@ -116,6 +113,9 @@ def create_assignment_graph(edges):
 
 @fused.udf
 def udf(bbox=None):
+    import geopandas as gpd
+    import numpy as np
+    import networkx as nx
     import re
     import requests
     import shapely

--- a/community/fhk/fcc_bdc_map_latest/fcc_bdc_map_latest.py
+++ b/community/fhk/fcc_bdc_map_latest/fcc_bdc_map_latest.py
@@ -39,9 +39,9 @@ def udf(
     tech_codes="[10,11,12,20,30,40,41,42,43,50]"): # Filter the data to only include these, https://www.fcc.gov/general/technology-codes-used-fixed-broadband-deployment-data
     # 10,11,12,20,30,40,41,42,43,50,60,70,90,0
     import json
-    utils = fused.load(
-            "https://github.com/fusedio/udfs/tree/f8f0c0f/public/common/"
-        ).utils
+    common = fused.load(
+    "https://github.com/fusedio/udfs/tree/f8f0c0f/public/common/"
+    ).utils
 
     unserved = json.loads(unserved)
     underserved = json.loads(underserved)
@@ -50,7 +50,7 @@ def udf(
     table_path = f"s3://fused-asset/data/fcc_bdc_map_latest/"
     table_path = table_path.rstrip("/")
     
-    gdf = utils.table_to_tile(bbox, table=table_path, use_columns=use_columns, min_zoom=8)
+    gdf = common.table_to_tile(bbox, table=table_path, use_columns=use_columns, min_zoom=8)
 
     gdf['brand_info'] = gdf.brand_info.apply(json.loads)
 

--- a/community/fhk/pybdshadow_example/pybdshadow_example.py
+++ b/community/fhk/pybdshadow_example/pybdshadow_example.py
@@ -1,6 +1,6 @@
-import geopandas as gpd
 @fused.udf
 def udf(
+    import geopandas as gpd
     bbox: fused.types.Bbox= None,
     polygon: gpd.GeoDataFrame = None,
     day: str = '2024-04-24',

--- a/community/milind/Show_Me_Tomato/Show_Me_Tomato.py
+++ b/community/milind/Show_Me_Tomato/Show_Me_Tomato.py
@@ -1,8 +1,8 @@
 common = fused.load("https://github.com/fusedio/udfs/tree/1469dfc/public/common/").utils
-import utils
 
 @fused.udf
 def udf(
+    import utils
     query: str = "show me water",
     bounds: fused.types.Bounds = [
         -125.82165127797666,21.313670812049978,-65.62955940309448,52.58604956417555

--- a/community/milind/Zarr_file_example/Zarr_file_example.py
+++ b/community/milind/Zarr_file_example/Zarr_file_example.py
@@ -8,8 +8,8 @@ def udf(bounds: fused.types.Bounds = None, layer: str = "ndvi", time: int = 2, t
     
 
     # Load utils
-    utils = fused.load(
-        "https://github.com/fusedio/udfs/tree/cbc5482/public/common/"
+    common = fused.load(
+    "https://github.com/fusedio/udfs/tree/cbc5482/public/common/"
     ).utils
     
     # Open dataset
@@ -47,7 +47,7 @@ def udf(bounds: fused.types.Bounds = None, layer: str = "ndvi", time: int = 2, t
     ).isel(time=time)
     
     # Process data
-    da = utils.da_fit_to_resolution(ds_buffer[layer], target_shape)
+    da = common.da_fit_to_resolution(ds_buffer[layer], target_shape)
     da = da.sel(latitude=slice(miny, maxy), longitude=slice(minx, maxx))
     
     # Reproject to Web Mercator for visualization
@@ -58,6 +58,6 @@ def udf(bounds: fused.types.Bounds = None, layer: str = "ndvi", time: int = 2, t
     
     # Mask and normalize
     masked_data = np.nan_to_num(data_array, nan=-2)
-    arr = utils.arr_to_plasma(masked_data, min_max=(-1, 1))
+    arr = common.arr_to_plasma(masked_data, min_max=(-1, 1))
     
     return arr

--- a/community/milind/chart_factory/chart_factory.py
+++ b/community/milind/chart_factory/chart_factory.py
@@ -1,9 +1,8 @@
-import fused
-import pandas as pd
-import numpy as np
 
 @fused.udf
 def udf(
+    import pandas as pd
+    import numpy as np
     bounds: fused.types.Bounds = [-74.014, 40.700, -74.000, 40.717],
     chart_type: str = "line",
     library: str = "echarts"

--- a/community/pgzmnk/terarrium_overture/terarrium_overture.py
+++ b/community/pgzmnk/terarrium_overture/terarrium_overture.py
@@ -28,7 +28,9 @@ def udf(bbox: fused.types.Tile, preview: bool = False):
         return None
 
     # Load pinned versions of utility functions.
-    utils = fused.load("https://github.com/fusedio/udfs/tree/ee9bec5/public/common/").utils
+    common = fused.load(
+    "https://github.com/fusedio/udfs/tree/ee9bec5/public/common/"
+    ).utils
     overture_utils = fused.load("https://github.com/fusedio/udfs/tree/ee9bec5/public/Overture_Maps_Example/").utils
     # Load Overture Buildings
     gdf_overture = overture_utils.get_overture(bbox=bbox)

--- a/community/plinio/Global_Surface_Water_H3/utils.py
+++ b/community/plinio/Global_Surface_Water_H3/utils.py
@@ -37,11 +37,17 @@ def ee_initialize(service_account_name="", key_path=""):
     ee.Initialize(opt_url='https://earthengine-highvolume.googleapis.com', credentials=credentials)
 
 
-utils = fused.load('https://github.com/fusedio/udfs/tree/004b8d9/public/common/').utils
+common = fused.load(
+
+
+"https://github.com/fusedio/udfs/tree/004b8d9/public/common/"
+
+
+).utils
 
 def get_data(bbox, year, land_type, chip_len):
         path= f"https://s3-us-west-2.amazonaws.com/mrlc/Annual_NLCD_LndCov_{year}_CU_C1V0.tif"
-        arr_int, color_map = utils.read_tiff(bbox, path, output_shape=(chip_len, chip_len), return_colormap=True)
+        arr_int, color_map = common.read_tiff(bbox, path, output_shape=(chip_len, chip_len), return_colormap=True)
         if land_type:
             arr_int = filter_lands(arr_int, land_type, verbose=False)    
         return arr_int, color_map

--- a/community/plinio/Zonal_Stats_Forest_Obs/Zonal_Stats_Forest_Obs.py
+++ b/community/plinio/Zonal_Stats_Forest_Obs/Zonal_Stats_Forest_Obs.py
@@ -13,7 +13,9 @@ def udf(
 
     from utils import get_asset_dissolve, rio_clip_geom_from_url, rio_clip_geom, zonal_stats_df, get_idx_range
     # Load pinned versions of utility functions.
-    utils = fused.load("https://github.com/fusedio/udfs/tree/ee9bec5/public/common/").utils
+    common = fused.load(
+    "https://github.com/fusedio/udfs/tree/ee9bec5/public/common/"
+    ).utils
 
     # 1. Get cell bounds for the cell
     gdf_cells = get_asset_dissolve(url=s3_file_path)
@@ -39,7 +41,7 @@ def udf(
         translate = True
 
     # 4. Create gdf_muni
-    gdf_muni = utils.table_to_tile(
+    gdf_muni = common.table_to_tile(
         gdf_cell,
         "s3://fused-asset/data/geoboundaries/adm2_064_v2/",
         use_columns=["shapeID", "geometry"],
@@ -63,7 +65,7 @@ def udf(
     # 5. Load tiff
     filename = gdf_cell[["url"]].iloc[0].values[0]
     tiff_url = f"s3://fused-asset/gfc2020/{filename}"
-    geom_bbox_muni = utils.geo_bbox(gdf_muni).geometry[0]
+    geom_bbox_muni = common.geo_bbox(gdf_muni).geometry[0]
     # return geom_bbox_muni
 
     # 6. Get TIFF dataset

--- a/community/plinio/Zonal_Stats_Forest_Obs_Runner/Zonal_Stats_Forest_Obs_Runner.py
+++ b/community/plinio/Zonal_Stats_Forest_Obs_Runner/Zonal_Stats_Forest_Obs_Runner.py
@@ -17,7 +17,9 @@ def udf(
     import itertools
 
     # Load pinned versions of utility functions.
-    utils = fused.load("https://github.com/fusedio/udfs/tree/ee9bec5/public/common/").utils
+    common = fused.load(
+    "https://github.com/fusedio/udfs/tree/ee9bec5/public/common/"
+    ).utils
     zonal_stats_utils = fused.load("https://github.com/fusedio/udfs/tree/ee9bec5/community/plinio/Zonal_Stats_Forest_Obs/").utils
 
     # 1. Define `cell_id` from the input dictionary
@@ -57,7 +59,7 @@ def udf(
         translate = True
 
     # 3. Create gdf_muni
-    gdf_muni = utils.table_to_tile(
+    gdf_muni = common.table_to_tile(
         gdf_cell,
         table_muni_geoboundaries,
         use_columns=["shapeID", "geometry"],
@@ -78,7 +80,7 @@ def udf(
     # 4. Load tiff
     filename = gdf_cell[["url"]].iloc[0].values[0]
     tiff_url = f"s3://fused-asset/gfc2020/{filename}"
-    geom_bbox_muni = utils.geo_bbox(gdf_muni).geometry[0]
+    geom_bbox_muni = common.geo_bbox(gdf_muni).geometry[0]
 
     # 5. Get TIFF dataset
     da, _ = zonal_stats_utils.rio_clip_geom_from_url(geom_bbox_muni, tiff_url)

--- a/community/sina/AirBnb_Listings/AirBnb_Listings.py
+++ b/community/sina/AirBnb_Listings/AirBnb_Listings.py
@@ -7,7 +7,7 @@ def udf(city='Paris', resolution=11):
     # set a resolution limit 
     if resolution > 11:resolution=11
 
-    common_utils = fused.load("https://github.com/fusedio/udfs/tree/3569595/public/common/").utils
+    common = fused.load("https://github.com/fusedio/udfs/tree/3569595/public/common/").utils
         
     @fused.cache
     def get_city_data(city):
@@ -35,7 +35,7 @@ def udf(city='Paris', resolution=11):
         out_path = f'{city}.csv.gz'
         csv_file = fused.core.download(url=url, file_path=out_path)
         
-        con = common_utils.duckdb_connect()
+        con = common.duckdb_connect()
         # reading data with duckDB and generating H3 cells
         @fused.cache
         def read_data(url, resolution):

--- a/community/sina/Airplane_Detection_AOI_v2/Airplane_Detection_AOI_v2.py
+++ b/community/sina/Airplane_Detection_AOI_v2/Airplane_Detection_AOI_v2.py
@@ -1,11 +1,11 @@
-import geopandas as gpd
-import json
 
+import json
 j = json.dumps({"type":"FeatureCollection","features":[{"type":"Feature","properties":{},"geometry":{"type":"Polygon","coordinates":[[[-122.4017963492825,37.628491164736616],[-122.38690611551642,37.606792625414464],[-122.38037214148257,37.60276024740176],[-122.37133040325998,37.61257919769027],[-122.35791086649414,37.60768132596657],[-122.35272358459858,37.61542869072087],[-122.36649356499498,37.62170750731398],[-122.36213655637812,37.628763217050896],[-122.37562464496435,37.63359108358579],[-122.39539369398146,37.63236203450454],[-122.4017963492825,37.628491164736616]]]}}]})
 common = fused.load("https://github.com/fusedio/udfs/tree/36f4e97/public/common/").utils
 
 @fused.udf
 def udf(target_gdf: gpd.GeoDataFrame = j, zoom: int=17):
+    import geopandas as gpd
     import geopandas as gpd
     import pandas as pd
     import json

--- a/community/sina/Arcgis_Rgb/Arcgis_Rgb.py
+++ b/community/sina/Arcgis_Rgb/Arcgis_Rgb.py
@@ -1,8 +1,10 @@
 @fused.udf
 def udf(bounds: fused.types.Bounds = [5.494,46.050,15.443,56.132]):
     # Load pinned versions of utility functions.
-    utils = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
-    bounds = utils.get_tiles(bounds, clip=True)
+    common = fused.load(
+    "https://github.com/fusedio/udfs/tree/2f41ae1/public/common/"
+    ).utils
+    bounds = common.get_tiles(bounds, clip=True)
     # Get the bounding box coordinates
     x, y, z = bounds[["x", "y", "z"]].iloc[0]
     # ArcGIS Online World Imagery basemap

--- a/community/sina/Arraylake_Example/arraylake_example.py
+++ b/community/sina/Arraylake_Example/arraylake_example.py
@@ -8,19 +8,18 @@ This UDF opens a dataset from Arraylake, subsets it to a bounding box, and coars
 NOTE: using Arraylake requires an Earthmover account. This UDF will only work for Earthmover customers.
 """
 
-from datetime import datetime
 
-import xarray as xr
-import fused
 
-import arraylake
 
 # remove this after Arraylake v0.13 is released an it becomes default
+import arraylake
 arraylake.config.set({"chunkstore.use_delegated_credentials": True})
 
 
 @fused.udf
 def udf(
+    from datetime import datetime
+    import xarray as xr
     bounds: fused.types.Bounds = [-58.483,-34.702,-58.376,-34.560],
     repo_name="earthmover-demos/sentinel-datacube-South-America-3",
     varname="rgb_median",

--- a/community/sina/Blank_Basemap/Blank_Basemap.py
+++ b/community/sina/Blank_Basemap/Blank_Basemap.py
@@ -1,7 +1,9 @@
 @fused.udf
 def udf(bounds: fused.types.Bounds = [-58.483,-34.702,-58.376,-34.560]):
     # convert bounds to tile
-    utils = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
-    tile = utils.get_tiles(bounds, clip=True)
+    common = fused.load(
+    "https://github.com/fusedio/udfs/tree/2f41ae1/public/common/"
+    ).utils
+    tile = common.get_tiles(bounds, clip=True)
 
     return tile

--- a/community/sina/Building_Tile_Example/Building_Tile_Example.py
+++ b/community/sina/Building_Tile_Example/Building_Tile_Example.py
@@ -1,5 +1,7 @@
 @fused.udf
 def udf(bounds: fused.types.Bounds = [-74.014,40.700,-74.000,40.717], table_path="s3://fused-asset/infra/building_msft_us"):
-    utils = fused.load("https://github.com/fusedio/udfs/tree/d0e8eb0/public/common/").utils
-    df = utils.table_to_tile(bounds, table=table_path)
+    common = fused.load(
+    "https://github.com/fusedio/udfs/tree/d0e8eb0/public/common/"
+    ).utils
+    df = common.table_to_tile(bounds, table=table_path)
     return df

--- a/community/sina/Census_ACS_5yr/Census_ACS_5yr.py
+++ b/community/sina/Census_ACS_5yr/Census_ACS_5yr.py
@@ -11,8 +11,8 @@ def udf(
     from utils import acs_5yr_bounds
 
     # Load pinned versions of utility functions.
-    common_utils = fused.load("https://github.com/fusedio/udfs/tree/bb712a5/public/common/").utils
-    zoom = common_utils.estimate_zoom(bounds)
+    common = fused.load("https://github.com/fusedio/udfs/tree/bb712a5/public/common/").utils
+    zoom = common.estimate_zoom(bounds)
 
     # different geometry details per zoom level
     if zoom > 12:

--- a/community/sina/Census_ACS_5yr/utils.py
+++ b/community/sina/Census_ACS_5yr/utils.py
@@ -16,7 +16,9 @@ def acs_5yr_bounds(
         raise ValueError('The only available years are 2021 and 2022')
 
     # Load pinned versions of utility functions.
-    utils = fused.load("https://github.com/fusedio/udfs/tree/d0e8eb0/public/common/").utils
+    common = fused.load(
+    "https://github.com/fusedio/udfs/tree/d0e8eb0/public/common/"
+    ).utils
 
     bounds = gpd.GeoDataFrame(geometry=[shapely.box(*bounds)], crs=4326)
     utils.import_env()
@@ -30,7 +32,7 @@ def acs_5yr_bounds(
     if suffix:
         table_path += f'_{suffix}'
     print(table_path)
-    gdf = utils.table_to_tile(
+    gdf = common.table_to_tile(
         bounds,
         table_path,
         use_columns=['GEOID','geometry'],

--- a/community/sina/Compute_TWI/Compute_TWI.py
+++ b/community/sina/Compute_TWI/Compute_TWI.py
@@ -20,8 +20,8 @@ min_max = (0, 15)
 def udf(bounds: fused.types.Bounds = [-77.595,38.250,-77.383,38.520], out_tif_name: str ='output', wbt_args: dict = wbt_args, min_max=min_max):
     import wbt
     # convert bounds to tile
-    common_utils = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
-    tile = common_utils.get_tiles(bounds, clip=True)
+    common = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
+    tile = common.get_tiles(bounds, clip=True)
 
     wbt_args = json.loads(wbt_args) if isinstance(wbt_args, str) else wbt_args
     return wbt.run(tile, wbt_args, out_tif_name, extra_input_files=None, min_max=min_max)

--- a/community/sina/Compute_TWI/wbt.py
+++ b/community/sina/Compute_TWI/wbt.py
@@ -1,6 +1,6 @@
 def run(bounds, wbt_args: dict[str, list[str]], out_tif_name: str, extra_input_files: list[str] | None = None, min_max: tuple[float, float] | None = None):
-    utils = fused.load(
-        "https://github.com/fusedio/udfs/tree/f928ee1/public/common/"
+    common = fused.load(
+    "https://github.com/fusedio/udfs/tree/f928ee1/public/common/"
     ).utils
     import tempfile
     import rioxarray
@@ -27,4 +27,4 @@ def run(bounds, wbt_args: dict[str, list[str]], out_tif_name: str, extra_input_f
         ds = rioxarray.open_rasterio(f"{tmp}/{out_tif_name}.tif").squeeze(drop=True)
         ds = ds.where(ds > ds.rio.nodata)
         arr = ds.rio.reproject(bounds.crs).rio.clip_box(*bounds.total_bounds).to_numpy()
-    return utils.arr_to_plasma(arr, min_max=min_max, reverse=False)
+    return common.arr_to_plasma(arr, min_max=min_max, reverse=False)

--- a/community/sina/Coverage_Model_ibis/Coverage_model_ibis.py
+++ b/community/sina/Coverage_Model_ibis/Coverage_model_ibis.py
@@ -17,8 +17,8 @@ def udf(bounds: fused.types.Bounds = [-122.438,37.774,-122.434,37.777], tech: st
     from utils import h3_cell_to_parent, h3_cell_to_boundary_wkt, ST_GeomFromText
 
     # convert bounds to tile
-    common_utils = fused.load("https://github.com/fusedio/udfs/tree/bb712a5/public/common/").utils
-    tile = common_utils.get_tiles(bounds, clip=True)
+    common = fused.load("https://github.com/fusedio/udfs/tree/bb712a5/public/common/").utils
+    tile = common.get_tiles(bounds, clip=True)
 
     @fused.cache
     def read_data(bounds, url: str, tech: str, site_count: int, col_plot: str, con_ibis):

--- a/community/sina/Create_A_Placekey_Join/Create_A_Placekey_Join.py
+++ b/community/sina/Create_A_Placekey_Join/Create_A_Placekey_Join.py
@@ -10,8 +10,8 @@ def udf(bounds: fused.types.Bounds = [-122.438,37.774,-122.434,37.777],
     import shapely
 
     # convert bounds to tile
-    common_utils = fused.load("https://github.com/fusedio/udfs/tree/bb712a5/public/common/").utils
-    tile = common_utils.get_tiles(bounds, clip=True)
+    common = fused.load("https://github.com/fusedio/udfs/tree/bb712a5/public/common/").utils
+    tile = common.get_tiles(bounds, clip=True)
 
     #get two placekey'd datasets; choose these based on what's available on the module tab
     df1 = get_placekeyd_dataset(tile, dataset1)

--- a/community/sina/Create_A_Placekey_Join/utils.py
+++ b/community/sina/Create_A_Placekey_Join/utils.py
@@ -7,14 +7,16 @@ def placekey_df_validate(df):
 
 @fused.cache
 def get_placekeyd_dataset(bounds, name: str):
-    utils = fused.load("https://github.com/fusedio/udfs/tree/d0e8eb0/public/common/").utils
+    common = fused.load(
+    "https://github.com/fusedio/udfs/tree/d0e8eb0/public/common/"
+    ).utils
     # pick one of these datasets!!
     datasets = set(['dc-healthy-corner-stores','home-health-agency-medicare-enrollments', 'home-infusion-therapy-provider-medicare-enrollments', 'hospice-medicare-enrollments', 'hospital-medicare-enrollments', 'national-downloadable-files-from-the-doctors-and-clinicians-data-section', 'skilled-nursing-facility-medicare-enrollments', 'rural-health-clinic-medicare-enrollments',
                    'national-provider-identifier', 'department-of-labor-wage-and-hour-compliance'])
     if name in datasets:
         path = 's3://placekey-free-datasets/'+name+'/fused/_sample'
         base_path = path.rsplit('/', maxsplit=1)[0] if path.endswith('/_sample') or path.endswith('/_metadata') else path
-        return utils.table_to_tile(bounds, table=base_path, use_columns=None)
+        return common.table_to_tile(bounds, table=base_path, use_columns=None)
     else:
         raise ValueError(name + " is either not available through Placekey or is not onboarded onto fused.io. Contact Placekey if you would like it to be! https://www.placekey.io/contact-sales")    
 

--- a/community/sina/Crop_Mask_Zonal_Statistics/Crop_Mask_Zonal_Statistics.py
+++ b/community/sina/Crop_Mask_Zonal_Statistics/Crop_Mask_Zonal_Statistics.py
@@ -14,7 +14,9 @@ def udf(engine='realtime', year: str = "2016", month: str = "07", period: str ="
         all_params = [{'geoid': geoid, 'year': year, 'crop_type': crop_type} for geoid in target_counties]
 
         # Load pinned versions of utility functions.
-        utils = fused.load("https://github.com/fusedio/udfs/tree/ee9bec5/public/common/").utils
+        common = fused.load(
+        "https://github.com/fusedio/udfs/tree/ee9bec5/public/common/"
+        ).utils
 
         # Run UDF in parallel
         @fused.cache
@@ -26,7 +28,7 @@ def udf(engine='realtime', year: str = "2016", month: str = "07", period: str ="
             df = fused.run(udf_nail, geoid=geoid, year=year, month=month, period=period, crop_type=crop_type, engine=engine)
             return df
     
-        dfs_out = utils.run_pool(hammer_udf, all_params, max_workers=64)
+        dfs_out = common.run_pool(hammer_udf, all_params, max_workers=64)
     
         # Concatenate all output tables
         gdf = pd.concat(dfs_out)
@@ -55,10 +57,12 @@ def udf(crop_type ="corn", geoid: str = '19119', year: str = "2015", month: str 
     print(area)
 
     # Load pinned versions of utility functions.
-    utils = fused.load("https://github.com/fusedio/udfs/tree/ee9bec5/public/common/").utils
+    common = fused.load(
+    "https://github.com/fusedio/udfs/tree/ee9bec5/public/common/"
+    ).utils
 
     # Get box around the geometry
-    geom_bbox = utils.geo_bbox(gdf)
+    geom_bbox = common.geo_bbox(gdf)
     
     # Dynamically construct the path based on the year and month
     path = f's3://soldatanasasifglobalifoco2modis1863/Global_SIF_OCO2_MODIS_1863/data/sif_ann_{year}{month}{period}.nc'
@@ -76,11 +80,13 @@ def udf(crop_type ="corn", geoid: str = '19119', year: str = "2015", month: str 
     sif_resized = resize(img, (arr_crop.shape[0],arr_crop.shape[1]), anti_aliasing=True, preserve_range=True).astype('uint8')
 
     # Sif for entire county prior to corn mask
-    utils = fused.load('https://github.com/fusedio/udfs/tree/ba8aeee/public/common/').utils
+    common = fused.load(
+    "https://github.com/fusedio/udfs/tree/ee9bec5/public/common/"
+    ).utils
     county_geom_mask = utils.gdf_to_mask_arr(gdf, sif_resized.shape[-2:], first_n=1) 
     sif_resized_county = np.ma.masked_array(sif_resized, mask=county_geom_mask)
     # return sif_resized_county, geom_bbox.total_bounds
-    # return utils.arr_to_plasma(sif_resized), geom_bbox.total_bounds # preview
+    # return common.arr_to_plasma(sif_resized), geom_bbox.total_bounds # preview
 
     # Preview clipped raster
     sif_resized_county_corn = sif_resized_county.copy()

--- a/community/sina/DC_AOI_Example/DC_AOI_Example.py
+++ b/community/sina/DC_AOI_Example/DC_AOI_Example.py
@@ -10,7 +10,9 @@ def udf(
     from utils import get_arr, rgbi_to_ndvi
 
     # Load pinned versions of utility functions.
-    utils = fused.load("https://github.com/fusedio/udfs/tree/ee9bec5/public/common/").utils
+    common = fused.load(
+    "https://github.com/fusedio/udfs/tree/ee9bec5/public/common/"
+    ).utils
 
     # Lad the geometry
     gdf = gpd.read_file('s3://fused-asset/data/tiger/TIGER_RD18/STATE/11_DISTRICT_OF_COLUMBIA/11/tl_rd22_11_tract.zip')

--- a/community/sina/DC_AOI_Example/utils.py
+++ b/community/sina/DC_AOI_Example/utils.py
@@ -2,8 +2,10 @@ import fused
 import numpy as np
 import palettable
 
-utils = fused.load(
-    "https://github.com/fusedio/udfs/tree/2b25cb3/public/common/"
+common = fused.load(
+
+"https://github.com/fusedio/udfs/tree/2b25cb3/public/common/"
+
 ).utils
 
 @fused.cache
@@ -42,7 +44,7 @@ def rgbi_to_ndvi(arr_rgbi):
     ndvi = (arr_rgbi[-1] * 1.0 - arr_rgbi[-2] * 1.0) / (
         arr_rgbi[-1] * 1.0 + arr_rgbi[-2] * 1.0
     )
-    rgb_image = utils.visualize(
+    rgb_image = common.visualize(
         data=ndvi,
         min=0,
         max=1,

--- a/community/sina/DC_AOI_Tile/DC_AOI_Tile.py
+++ b/community/sina/DC_AOI_Tile/DC_AOI_Tile.py
@@ -6,8 +6,8 @@ def udf(bounds: fused.types.Bounds=[-77.083,38.849,-76.969,38.938], time_of_inte
     import numpy as np
 
     # convert bounds to tile
-    common_utils = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
-    tile = common_utils.get_tiles(bounds, clip=True)
+    common = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
+    tile = common.get_tiles(bounds, clip=True)
 
     # find the tiles with intersecting geom
     gdf = gpd.read_file('s3://fused-asset/data/tiger/TIGER_RD18/STATE/11_DISTRICT_OF_COLUMBIA/11/tl_rd22_11_tract.zip')
@@ -23,7 +23,9 @@ def udf(bounds: fused.types.Bounds=[-77.083,38.849,-76.969,38.938], time_of_inte
     arr = np.clip(arr *  scale, 0, 255).astype("uint8")[:3]
 
     # Load pinned versions of utility functions.
-    utils = fused.load("https://github.com/fusedio/udfs/tree/ee9bec5/public/common/").utils
+    common = fused.load(
+    "https://github.com/fusedio/udfs/tree/2f41ae1/public/common/"
+    ).utils
 
     # create a geom mask
     geom_mask = utils.gdf_to_mask_arr(gdf_w_bounds, arr.shape[-2:], first_n=1)    

--- a/community/sina/DC_AOI_Tile_Hex/DC_AOI_Tile_Hex.py
+++ b/community/sina/DC_AOI_Tile_Hex/DC_AOI_Tile_Hex.py
@@ -7,8 +7,8 @@ def udf(bounds: fused.types.Bounds=[-77.083,38.804,-76.969,38.983], time_of_inte
     from utils import tile_to_df, df_to_hex
 
     # convert bounds to tile
-    common_utils = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
-    tile = common_utils.get_tiles(bounds, clip=True)
+    common = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
+    tile = common.get_tiles(bounds, clip=True)
 
     
     # find the tiles with intersecting geom
@@ -25,7 +25,9 @@ def udf(bounds: fused.types.Bounds=[-77.083,38.804,-76.969,38.983], time_of_inte
     arr = np.clip(arr *  scale, 0, 255).astype("uint8")[:3]
     
     # Load pinned versions of utility functions.
-    utils = fused.load("https://github.com/fusedio/udfs/tree/ee9bec5/public/common/").utils
+    common = fused.load(
+    "https://github.com/fusedio/udfs/tree/2f41ae1/public/common/"
+    ).utils
     # create a geom mask
     geom_mask = utils.gdf_to_mask_arr(gdf_w_bounds, arr.shape[-2:], first_n=1)    
     arr = np.ma.masked_array(arr, [geom_mask]*arr.shape[0])

--- a/community/sina/DC_AOI_Tile_Hex/utils.py
+++ b/community/sina/DC_AOI_Tile_Hex/utils.py
@@ -1,7 +1,7 @@
 def df_to_hex(df, data_cols=['data'], h3_size=9, hex_col='hex', latlng_col=['lat','lng'], ordered=False, return_avg_lalng=True):
     duckdb_connect = fused.load(
             "https://github.com/fusedio/udfs/tree/3569595/public/common/"
-        ).utils.duckdb_connect
+        ).common.duckdb_connect
     agg_term = ', '.join([f'ARRAY_AGG({col}) as agg_{col}' for col in data_cols])
     if return_avg_lalng:
         agg_term+=f', avg({latlng_col[0]}) as {latlng_col[0]}_avg, avg({latlng_col[1]}) as {latlng_col[1]}_avg'
@@ -37,7 +37,9 @@ def tile_to_df(bounds, arr, return_geometry=False):
     df["lat"] = Y.flatten()
 
     # Load pinned versions of utility functions.
-    utils = fused.load("https://github.com/fusedio/udfs/tree/ee9bec5/public/common/").utils
+    common = fused.load(
+    "https://github.com/fusedio/udfs/tree/3569595/public/common/"
+    ).utils
 
     # convert back to 4326
     df = utils.geo_convert(df).set_crs(3857, allow_override=True).to_crs(bounds.crs)

--- a/community/sina/DEM_10m_Tile_Example/DEM_10m_Tile_Example.py
+++ b/community/sina/DEM_10m_Tile_Example/DEM_10m_Tile_Example.py
@@ -13,8 +13,10 @@ def udf(
     from pystac.extensions.eo import EOExtension as eo
 
     # Load pinned versions of utility functions.
-    utils = fused.load("https://github.com/fusedio/udfs/tree/bb712a5/public/common/").utils
-    zoom = utils.estimate_zoom(bounds)
+    common = fused.load(
+    "https://github.com/fusedio/udfs/tree/bb712a5/public/common/"
+    ).utils
+    zoom = common.estimate_zoom(bounds)
 
     catalog = pystac_client.Client.open(
         "https://planetarycomputer.microsoft.com/api/stac/v1",
@@ -40,7 +42,7 @@ def udf(
     arr = ds[band].max(dim="time")
     
     # Visualize that data as an RGB image.
-    rgb_image = utils.visualize(
+    rgb_image = common.visualize(
         data=arr,
         min=0,
         max=100,

--- a/community/sina/DEM_Tile_Example/DEM_Tile_Example.py
+++ b/community/sina/DEM_Tile_Example/DEM_Tile_Example.py
@@ -10,8 +10,8 @@ def udf(
     import utils
 
     # Load pinned versions of utility functions.
-    common_utils = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
-    tile = common_utils.get_tiles(bounds, clip=True)
+    common = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
+    tile = common.get_tiles(bounds, clip=True)
     zoom = tile.iloc[0].z
 
     print(f'{type(tile) = }')
@@ -56,7 +56,7 @@ def udf(
     arr = xarray_dataset["data"].max(dim="time")
 
     # Visualize that data as an RGB image.
-    rgb_image = utils.visualize(
+    rgb_image = common.visualize(
         data=arr,
         min=0,
         max=3000,

--- a/community/sina/DEM_Tile_Hexify/DEM_Tile_Hexify.py
+++ b/community/sina/DEM_Tile_Hexify/DEM_Tile_Hexify.py
@@ -5,8 +5,8 @@ def udf(bounds: fused.types.Bounds = [-90.691,-21.719,-21.300,75.897], stats_typ
     from utils import aggregate_df_hex, url_to_plasma
 
     # convert bounds to tile
-    common_utils = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
-    tile = common_utils.get_tiles(bounds, clip=True)
+    common = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
+    tile = common.get_tiles(bounds, clip=True)
 
     # 1. Initial parameters
     x, y, z = tile.iloc[0][["x", "y", "z"]]

--- a/community/sina/DEM_Tile_Hexify/utils.py
+++ b/community/sina/DEM_Tile_Hexify/utils.py
@@ -1,12 +1,12 @@
-utils = fused.load("https://github.com/fusedio/udfs/tree/be3bc93/public/common/").utils
+common = fused.load("https://github.com/fusedio/udfs/tree/be3bc93/public/common/").utils
 url_to_arr=utils.url_to_arr
 def url_to_plasma(url, min_max=None, colormap='plasma'):
-    return utils.arr_to_plasma(utils.url_to_arr(url).squeeze(), min_max=min_max, colormap=colormap, reverse=False)
+    return common.arr_to_plasma(utils.url_to_arr(url).squeeze(), min_max=min_max, colormap=colormap, reverse=False)
     
 @fused.cache
 def df_to_hex(df, res, latlng_cols=("lat", "lng")):
-    utils = fused.load(
-        "https://github.com/fusedio/udfs/tree/be3bc93/public/common/"
+    common = fused.load(
+    "https://github.com/fusedio/udfs/tree/be3bc93/public/common/"
     ).utils
     qr = f"""
             SELECT h3_latlng_to_cell({latlng_cols[0]}, {latlng_cols[1]}, {res}) AS hex, ARRAY_AGG(data) as agg_data
@@ -14,7 +14,7 @@ def df_to_hex(df, res, latlng_cols=("lat", "lng")):
             group by 1
           --  order by 1
         """
-    con = utils.duckdb_connect()
+    con = common.duckdb_connect()
     return con.query(qr).df()
 
 

--- a/community/sina/DL4EO_Airplane_Detection/DL4EO_Airplane_Detection.py
+++ b/community/sina/DL4EO_Airplane_Detection/DL4EO_Airplane_Detection.py
@@ -1,8 +1,10 @@
-import geopandas as gpd
 
 @fused.udf
 def udf_rgb_tiles(tile: gpd.GeoDataFrame):
-    utils = fused.load('https://github.com/fusedio/udfs/tree/004b8d9/public/common/').utils
+    import geopandas as gpd
+    common = fused.load(
+    "https://github.com/fusedio/udfs/tree/004b8d9/public/common/"
+    ).utils
     x, y, z = tile[["x", "y", "z"]].iloc[0]
     return utils.url_to_arr(f"https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}")
 
@@ -23,9 +25,9 @@ def udf(
     import numpy as np
 
     # convert bounds to tile
-    common_utils = fused.load("https://github.com/fusedio/udfs/tree/bb712a5/public/common/").utils
-    zoom = common_utils.estimate_zoom(bounds)
-    tile = common_utils.get_tiles(bounds, zoom=zoom)
+    common = fused.load("https://github.com/fusedio/udfs/tree/004b8d9/public/common/").utils
+    zoom = common.estimate_zoom(bounds)
+    tile = common.get_tiles(bounds, zoom=zoom)
 
 
     # Load imagery

--- a/community/sina/DSM_JAXA_Example/DSM_JAXA_Example.py
+++ b/community/sina/DSM_JAXA_Example/DSM_JAXA_Example.py
@@ -13,7 +13,7 @@ def udf(
     import utils
     
     arr = utils.dsm_to_tile(bounds=bounds, z_levels=z_levels, verbose=verbose)
-    return utils.common_utils.visualize(
+    return utils.common.visualize(
         data=arr,
         min=0,
         max=3000,

--- a/community/sina/DSM_JAXA_Example/utils.py
+++ b/community/sina/DSM_JAXA_Example/utils.py
@@ -2,7 +2,7 @@ import fused
 import geopandas as gpd
 
 # Load utility functions.
-common_utils = fused.load("https://github.com/fusedio/udfs/tree/bb712a5/public/common/").utils
+common = fused.load("https://github.com/fusedio/udfs/tree/bb712a5/public/common/").utils
 
 def dsm_to_tile(
     bounds: fused.types.Bounds,
@@ -10,7 +10,7 @@ def dsm_to_tile(
     verbose=True
 ):
 
-    tile = common_utils.get_tiles(bounds)
+    tile = common.get_tiles(bounds)
     zoom = tile.iloc[0].z
 
     if zoom >= z_levels[2]:
@@ -47,7 +47,7 @@ def dsm_to_tile(
         return tile
     if verbose:
         print(tiff_list)
-    arr = common_utils.mosaic_tiff(tile, tiff_list, overview_level=overview_level)
+    arr = common.mosaic_tiff(tile, tiff_list, overview_level=overview_level)
     return arr
 
 

--- a/community/sina/DSM_Zonal_Stats/DSM_Zonal_Stats.py
+++ b/community/sina/DSM_Zonal_Stats/DSM_Zonal_Stats.py
@@ -3,13 +3,15 @@ def udf(
     bounds: fused.types.Bounds= [-122.416,37.773,-122.383,37.792], min_zoom=15, table="s3://fused-asset/infra/building_msft_us/", chip_len=256
 ):
     # Load pinned versions of utility functions.
-    utils = fused.load("https://github.com/fusedio/udfs/tree/d0e8eb0/public/common/").utils
+    common = fused.load(
+    "https://github.com/fusedio/udfs/tree/d0e8eb0/public/common/"
+    ).utils
     dsm_utils = fused.load("https://github.com/fusedio/udfs/blob/5bc22d7/public/DSM_JAXA_Example/").utils
 
-    zoom = utils.estimate_zoom(bounds)
+    zoom = common.estimate_zoom(bounds)
 
     if zoom >= min_zoom:
-        gdf = utils.table_to_tile(bounds, table, min_zoom)
+        gdf = common.table_to_tile(bounds, table, min_zoom)
         arr = dsm_utils.dsm_to_tile(bounds, z_levels=[4, 6, 9, 11], verbose=False)
         gdf_zonal = utils.geom_stats(gdf, arr, output_shape=(chip_len, chip_len))
         return gdf_zonal

--- a/community/sina/DSM_Zonal_Stats/utils.py
+++ b/community/sina/DSM_Zonal_Stats/utils.py
@@ -1,8 +1,8 @@
 import fused
 
-common_utils = fused.load("https://github.com/fusedio/udfs/tree/d0e8eb0/public/common/").utils
-table_to_tile = common_utils.table_to_tile
-geom_stats = common_utils.geom_stats
+common = fused.load("https://github.com/fusedio/udfs/tree/d0e8eb0/public/common/").utils
+table_to_tile = common.table_to_tile
+geom_stats = common.geom_stats
 dsm_to_tile = fused.load(
     "https://github.com/fusedio/udfs/tree/91845c4/public/DSM_JAXA_Example"
 ).utils.dsm_to_tile

--- a/community/sina/DuckDB_H3_Example/DuckDB_H3_Example.py
+++ b/community/sina/DuckDB_H3_Example/DuckDB_H3_Example.py
@@ -5,8 +5,8 @@ def udf(bounds: fused.types.Bounds = [-74.033,40.648,-73.788,40.846], resolution
     import shapely
     import geopandas as gpd
 
-    common_utils = fused.load("https://github.com/fusedio/udfs/tree/3569595/public/common/").utils
-    con = common_utils.duckdb_connect()
+    common = fused.load("https://github.com/fusedio/udfs/tree/3569595/public/common/").utils
+    con = common.duckdb_connect()
 
     @fused.cache
     def read_data(url, resolution, min_count):

--- a/community/sina/DuckDB_H3_SF/DuckDB_H3_SF.py
+++ b/community/sina/DuckDB_H3_SF/DuckDB_H3_SF.py
@@ -1,8 +1,8 @@
 @fused.udf
 def udf(count: int = 0):
     # Create duckdb connection
-    common_utils = fused.load("https://github.com/fusedio/udfs/tree/3569595/public/common/").utils
-    con = common_utils.duckdb_connect()
+    common = fused.load("https://github.com/fusedio/udfs/tree/3569595/public/common/").utils
+    con = common.duckdb_connect()
 
     # Load and return data
     path = "https://raw.githubusercontent.com/visgl/deck.gl-data/master/website/sf.h3cells.json"

--- a/community/sina/EPC_Ratings/EPC_Ratings.py
+++ b/community/sina/EPC_Ratings/EPC_Ratings.py
@@ -2,8 +2,8 @@
 def udf(bounds: fused.types.Bounds = [-2.997,53.399,-2.975,53.412]):
 
     # convert bounds to tile
-    common_utils = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
-    tile = common_utils.get_tiles(bounds, clip=True)
+    common = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
+    tile = common.get_tiles(bounds, clip=True)
 
     # Load Addresscloud data
     path: str = "s3://us-west-2.opendata.source.coop/addresscloud/epc/geoparquet-local-authority/Liverpool.parquet"

--- a/community/sina/FEMA_Buildings_US/FEMA_Buildings_US.py
+++ b/community/sina/FEMA_Buildings_US/FEMA_Buildings_US.py
@@ -2,6 +2,10 @@
 def udf(bounds: fused.types.Bounds = [-74.008,40.684,-73.971,40.713]):
     path='s3://fused-asset/infra/building_oak/'
 
-    utils = fused.load("https://github.com/fusedio/udfs/tree/d0e8eb0/public/common/").utils
-    df = utils.table_to_tile(bounds, table=path, use_columns=None, min_zoom=13)
+    common = fused.load(
+
+    "https://github.com/fusedio/udfs/tree/d0e8eb0/public/common/"
+
+    ).utils
+    df = common.table_to_tile(bounds, table=path, use_columns=None, min_zoom=13)
     return df

--- a/community/sina/Five_Minutes_Away_in_Bushwick_Brooklyn/Five_Minutes_Away_in_Bushwick_Brooklyn.py
+++ b/community/sina/Five_Minutes_Away_in_Bushwick_Brooklyn/Five_Minutes_Away_in_Bushwick_Brooklyn.py
@@ -13,8 +13,8 @@ def udf(bounds: fused.types.Bounds = [-73.941,40.690,-73.892,40.740],
     from utils import get_fsq_isochrones_gdf, fsq_isochrones_to_h3, bushwick_boundary
 
     # convert bounds to tile
-    common_utils = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
-    tile = common_utils.get_tiles(bounds, clip=True)
+    common = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
+    tile = common.get_tiles(bounds, clip=True)
 
     
     # This pulls 5 minute walking isochrones around FSQ coffee shops

--- a/community/sina/Five_Minutes_Away_in_Bushwick_Brooklyn/utils.py
+++ b/community/sina/Five_Minutes_Away_in_Bushwick_Brooklyn/utils.py
@@ -42,10 +42,12 @@ def get_pool_isochrones(df, costing, time_steps):
     if len(df) == 0:
         return gpd.GeoDataFrame(geometry=[], crs="EPSG:4326")
     # Load pinned versions of utility functions.
-    utils = fused.load("https://github.com/fusedio/udfs/tree/ee9bec5/public/common/").utils
+    common = fused.load(
+    "https://github.com/fusedio/udfs/tree/ee9bec5/public/common/"
+    ).utils
     # Using the Fused common run_pool function 
     arg_list = [(point, costing, time_steps) for point in df.geometry]
-    isochrones = utils.run_pool(get_single_isochrone, arg_list)
+    isochrones = common.run_pool(get_single_isochrone, arg_list)
     
     # Track which isochrones are valid along with their names
     valid_pairs = [(iso, name) for iso, name in zip(isochrones, df['name']) if len(iso) > 0]
@@ -82,9 +84,11 @@ def get_fsq_isochrones_gdf(costing, time_steps, poi_category):
 @fused.cache
 def fsq_isochrones_to_h3(df_fsq_isochrones, resolution):
     # Load pinned versions of utility functions.
-    utils = fused.load("https://github.com/fusedio/udfs/tree/ee9bec5/public/common/").utils
+    common = fused.load(
+    "https://github.com/fusedio/udfs/tree/ee9bec5/public/common/"
+    ).utils
     # Connect to DuckDB
-    con = utils.duckdb_connect()
+    con = common.duckdb_connect()
     # Convert the isochrones into H3, count the overlap and keep the POI name
     query = f"""
     with to_cells as (

--- a/community/sina/Foursquare_Open_Source_Places/Foursquare_Open_Source_Places.py
+++ b/community/sina/Foursquare_Open_Source_Places/Foursquare_Open_Source_Places.py
@@ -7,10 +7,14 @@ def udf(
 ):
     from utils import join_fsq_categories
 
-    utils = fused.load("https://github.com/fusedio/udfs/tree/d0e8eb0/public/common/").utils
+    common = fused.load(
+
+    "https://github.com/fusedio/udfs/tree/d0e8eb0/public/common/"
+
+    ).utils
 
     path = f"s3://us-west-2.opendata.source.coop/fused/fsq-os-places/{release}/places/"
-    df = utils.table_to_tile(
+    df = common.table_to_tile(
         bounds, table=path, min_zoom=min_zoom, use_columns=use_columns
     )
 

--- a/community/sina/GOES_Globe_Animation/GOES_Globe_Animation.py
+++ b/community/sina/GOES_Globe_Animation/GOES_Globe_Animation.py
@@ -23,7 +23,11 @@ def udf(
         import imageio
         import numpy as np
 
-        utils = fused.load("https://github.com/fusedio/udfs/tree/7306c98/public/common/").utils  
+        common = fused.load(
+
+        "https://github.com/fusedio/udfs/tree/7306c98/public/common/"
+
+        ).utils  
     
         bounds = [float(i) for i in bounds.split(",")]
 
@@ -58,7 +62,9 @@ def udf(
 
 @fused.udf   
 def udf_nail(i: int = 0, datestr:str ='2024-06-19',coarsen_factor:int=20, bounds:str ='-180,-10,-65,70' , product_name:str ='ABI-L2-CMIPF', bucket_name:str ='noaa-goes18', offset:str ='0', band: int=8, x_res: int=40, y_res: int=40): 
-    utils = fused.load("https://github.com/fusedio/udfs/tree/7306c98/public/common/").utils  
+    common = fused.load( 
+    "https://github.com/fusedio/udfs/tree/7306c98/public/common/" 
+    ).utils  
     import geopandas as gpd 
     import shapely
     import json
@@ -80,6 +86,6 @@ def udf_nail(i: int = 0, datestr:str ='2024-06-19',coarsen_factor:int=20, bounds
         ds = xds_roi = (xds.coarsen(x=coarsen_factor, y=coarsen_factor, boundary='trim').max())
         return ds[var]  
     da = fn(bbox, i, product_name, var, datestr=datestr, offset=offset, band=band, x_res=x_res, y_res=y_res, coarsen_factor=coarsen_factor)
-    arr = utils.arr_to_plasma(da.values.squeeze(), min_max=min_max, colormap='')
+    arr = common.arr_to_plasma(da.values.squeeze(), min_max=min_max, colormap='')
     return arr
     

--- a/community/sina/GeoPython_spherical_area/GeoPython_spherical_area.py
+++ b/community/sina/GeoPython_spherical_area/GeoPython_spherical_area.py
@@ -5,8 +5,8 @@ def udf(bounds: fused.types.Bounds = [7.634,47.528,7.651,47.540]):
     sys.path.append(f"/mnt/cache/envs/geopython/lib/python3.11/site-packages")
 
     # convert bounds to tile
-    common_utils = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
-    tile = common_utils.get_tiles(bounds, clip=True)
+    common = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
+    tile = common.get_tiles(bounds, clip=True)
 
     # loading the Overture building polygons for the current bounds
     from utils import get_overture

--- a/community/sina/GeoPython_spherical_area/utils.py
+++ b/community/sina/GeoPython_spherical_area/utils.py
@@ -20,8 +20,10 @@ def get_overture(
     from shapely.geometry import shape, box
 
     # convert bounds to tile
-    utils = fused.load("https://github.com/fusedio/udfs/tree/d0e8eb0/public/common/").utils
-    tile = utils.get_tiles(bounds)
+    common = fused.load(
+    "https://github.com/fusedio/udfs/tree/d0e8eb0/public/common/"
+    ).utils
+    tile = common.get_tiles(bounds)
 
     if release == "2024-02-15-alpha-0":
         if overture_type == "administrative_boundary":
@@ -103,7 +105,7 @@ def get_overture(
     def get_part(part):
         part_path = f"{table_path}/part={part}/" if num_parts != 1 else table_path
         try:
-            return utils.table_to_tile(
+            return common.table_to_tile(
                 tile, table=part_path, use_columns=use_columns, min_zoom=min_zoom
             )
         except ValueError:

--- a/community/sina/Geoparquet_STAC_Land_Productivity/Geoparquet_STAC_Land_Productivity.py
+++ b/community/sina/Geoparquet_STAC_Land_Productivity/Geoparquet_STAC_Land_Productivity.py
@@ -9,13 +9,13 @@ def udf(
     from pystac import Item
 
     # Load pinned versions of utility functions.
-    common_utils = fused.load("https://github.com/fusedio/udfs/tree/bb712a5/public/common/").utils
-    zoom = common_utils.estimate_zoom(bounds)
+    common = fused.load("https://github.com/fusedio/udfs/tree/bb712a5/public/common/").utils
+    zoom = common.estimate_zoom(bounds)
 
     # Load utility functions
     visualize = fused.load(
         "https://github.com/fusedio/udfs/tree/5cfb808/public/common/"
-    ).utils.visualize
+    ).common.visualize
 
     # Author: Alex Leith, with inspiration from other examples
 

--- a/community/sina/HLS_Tile_Example/HLS_Tile_Example.py
+++ b/community/sina/HLS_Tile_Example/HLS_Tile_Example.py
@@ -15,8 +15,10 @@ def udf(
     from utils_local import list_stac_collections
 
     # convert bounds to tile
-    utils = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
-    tile = utils.get_tiles(bounds, clip=True)
+    common = fused.load(
+    "https://github.com/fusedio/udfs/tree/2f41ae1/public/common/"
+    ).utils
+    tile = common.get_tiles(bounds, clip=True)
 
     STAC_URL = "https://cmr.earthdata.nasa.gov/stac"
 
@@ -90,7 +92,7 @@ def udf(
             cred=cred,
         )
         # Visualize data as an RGB image.
-        rgb_image = utils.visualize(
+        rgb_image = common.visualize(
             data=arr,
             min=min_max[0],
             max=min_max[1],

--- a/community/sina/Hexagonify_raster_from_url/Hexagonify_raster_from_url.py
+++ b/community/sina/Hexagonify_raster_from_url/Hexagonify_raster_from_url.py
@@ -24,8 +24,8 @@ def udf(raster_path = 'https://s3.amazonaws.com/elevation-tiles-prod/geotiff/4/4
 
 @fused.cache
 def df_to_hex(df, res, latlng_cols=("lat", "lng")):
-    utils = fused.load(
-        "https://github.com/fusedio/udfs/tree/be3bc93/public/common/"
+    common = fused.load(
+    "https://github.com/fusedio/udfs/tree/be3bc93/public/common/"
     ).utils
     qr = f"""
             SELECT h3_latlng_to_cell({latlng_cols[0]}, {latlng_cols[1]}, {res}) AS hex, ARRAY_AGG(data) as agg_data
@@ -33,7 +33,7 @@ def df_to_hex(df, res, latlng_cols=("lat", "lng")):
             group by 1
           --  order by 1
         """
-    con = utils.duckdb_connect()
+    con = common.duckdb_connect()
     return con.query(qr).df()
 
 

--- a/community/sina/Invasive_Species_Hotspot/Invasive_Species_Hotspot.py
+++ b/community/sina/Invasive_Species_Hotspot/Invasive_Species_Hotspot.py
@@ -8,8 +8,8 @@ def udf(
     from utils import get_strahler_gdf, create_h3_buffer_scored
 
     # convert bounds to tile
-    common_utils = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
-    tile = common_utils.get_tiles(bounds, clip=True)
+    common = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
+    tile = common.get_tiles(bounds, clip=True)
 
 
     overture_utils = fused.load("https://github.com/fusedio/udfs/tree/2ea46f3/public/Overture_Maps_Example/").utils # Load pinned versions of utility functions.

--- a/community/sina/Invasive_Species_Hotspot/utils.py
+++ b/community/sina/Invasive_Species_Hotspot/utils.py
@@ -45,7 +45,9 @@ def get_strahler_gdf(bounds):
     VARNAME='b1'
 
     # Load pinned versions of utility functions.
-    utils = fused.load("https://github.com/fusedio/udfs/tree/ee9bec5/public/common/").utils
+    common = fused.load(
+    "https://github.com/fusedio/udfs/tree/ee9bec5/public/common/"
+    ).utils
 
     # Set your own creds
     utils.ee_initialize(service_account_name='fused-nyt-gee@fused-nyt.iam.gserviceaccount.com',key_path="/mnt/cache/gee_creds/fusedbenchmark-513a57ac463f.json")

--- a/community/sina/LANDFIRE_Wildfire_Ignition_Behavior_Models/wildfire_ignition_types.py
+++ b/community/sina/LANDFIRE_Wildfire_Ignition_Behavior_Models/wildfire_ignition_types.py
@@ -12,8 +12,8 @@ def udf(
     import pandas as pd
 
     # convert bounds to tile
-    common_utils = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
-    tile = common_utils.get_tiles(bounds, clip=True)
+    common = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
+    tile = common.get_tiles(bounds, clip=True)
 
 
     envelope = tile.geometry.envelope

--- a/community/sina/LULC_Tile_Example/LULC_Tile_Example.py
+++ b/community/sina/LULC_Tile_Example/LULC_Tile_Example.py
@@ -1,11 +1,10 @@
-import fused
 
 @fused.udf
 def udf(bounds: fused.types.Bounds = [-122.499,37.707,-122.381,37.808], year="2022", chip_len:int=256):
 
     # Load pinned versions of utility functions.
-    common_utils = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
-    tile = common_utils.get_tiles(bounds, clip=True)
+    common = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
+    tile = common.get_tiles(bounds, clip=True)
     zoom = tile.iloc[0].z
 
     if zoom >= 5:

--- a/community/sina/Landsat_Tile_Example/Landsat_Tile_Example.py
+++ b/community/sina/Landsat_Tile_Example/Landsat_Tile_Example.py
@@ -14,8 +14,10 @@ def udf(
     from pystac.extensions.eo import EOExtension as eo
 
     # Load pinned versions of utility functions.
-    utils = fused.load("https://github.com/fusedio/udfs/tree/bb712a5/public/common/").utils
-    zoom = utils.estimate_zoom(bounds)
+    common = fused.load(
+    "https://github.com/fusedio/udfs/tree/bb712a5/public/common/"
+    ).utils
+    zoom = common.estimate_zoom(bounds)
 
     catalog = pystac_client.Client.open("https://earth-search.aws.element84.com/v1")
     
@@ -48,7 +50,7 @@ def udf(
     # Select the maximum value across all times
     arr = ndvi.max(dim="time")
   
-    return utils.visualize(
+    return common.visualize(
         arr.values,
         min=0,
         max=0.5,

--- a/community/sina/NAIP_Tile_Example/NAIP_Tile_Example.py
+++ b/community/sina/NAIP_Tile_Example/NAIP_Tile_Example.py
@@ -6,8 +6,10 @@ def udf(
     buffer_degree=0.000,
 ):
     # convert bounds to tile
-    utils = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
-    tile = utils.get_tiles(bounds, clip=True)
+    common = fused.load(
+    "https://github.com/fusedio/udfs/tree/2f41ae1/public/common/"
+    ).utils
+    tile = common.get_tiles(bounds, clip=True)
     zoom = tile.iloc[0].z
 
     min_zoom = 15

--- a/community/sina/NEON_Hyperspectral_GEE/NEON_Hyperspectral_GEE.py
+++ b/community/sina/NEON_Hyperspectral_GEE/NEON_Hyperspectral_GEE.py
@@ -12,8 +12,10 @@ def udf(
     import json
      
     # convert bounds to tile
-    utils = fused.load("https://github.com/fusedio/udfs/tree/bb712a5/public/common/").utils
-    tile = utils.get_tiles(bounds)
+    common = fused.load(
+    "https://github.com/fusedio/udfs/tree/bb712a5/public/common/"
+    ).utils
+    tile = common.get_tiles(bounds)
     zoom = tile.iloc[0].z
 
     # Authenticate GEE

--- a/community/sina/NEON_Hyperspectral_GEE/utils.py
+++ b/community/sina/NEON_Hyperspectral_GEE/utils.py
@@ -9,8 +9,8 @@ def fetch_rgb_udf(
     import xee
 
     # convert bounds to tile
-    common_utils = fused.load("https://github.com/fusedio/udfs/tree/bb712a5/public/common/").utils
-    tile = common_utils.get_tiles(bounds)
+    common = fused.load("https://github.com/fusedio/udfs/tree/bb712a5/public/common/").utils
+    tile = common.get_tiles(bounds)
 
     # Authenticate GEE
     key_path = "/mnt/cache/gp_creds.json"

--- a/community/sina/NEX_GDDP_Cmip6_VIDA/NEX_GDDP_Cmip6_VIDA.py
+++ b/community/sina/NEX_GDDP_Cmip6_VIDA/NEX_GDDP_Cmip6_VIDA.py
@@ -11,8 +11,8 @@ def udf(
     import xarray as xr
 
     # convert bounds to tile
-    common_utils = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
-    tile = common_utils.get_tiles(bounds, clip=True)
+    common = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
+    tile = common.get_tiles(bounds, clip=True)
 
 
     ds = xr.open_zarr("gs://fused_public/zarr/wri_cmip6_median_ssp585.zarr")
@@ -20,7 +20,7 @@ def udf(
     if tile["z"].iloc[0] < 1:
         print("z less than 1")
         return
-    utils = fused.load("https://github.com/fusedio/udfs/tree/cbc5482/public/common/").utils
+    common = fused.load("https://github.com/fusedio/udfs/tree/cbc5482/public/common/").utils
 
     minx, miny, maxx, maxy = bounds
     variable_names = list(ds.data_vars)
@@ -38,7 +38,7 @@ def udf(
     buffer = ds.lon[1] - ds.lon[0]
     ds = ds.sel(time=2080)
     ds_buffer = ds.sel(lat=slice(miny - buffer, maxy + buffer), lon=slice(minx - buffer, maxx + buffer))
-    da = utils.da_fit_to_resolution(ds_buffer[layer], target_shape)
+    da = common.da_fit_to_resolution(ds_buffer[layer], target_shape)
     da = da.sel(lat=slice(miny, maxy), lon=slice(minx, maxx))
     da = da.rename({"lat": "y", "lon": "x"})
     # Reprojecting to Web Mercator for visualization
@@ -55,7 +55,7 @@ def udf(
     # Masking the NaN values and replcing with values outside min max
     masked_data = np.nan_to_num(data_array, nan=valid_min - 1)
     # Using the minmax for color mapping
-    arr = utils.arr_to_plasma(
+    arr = common.arr_to_plasma(
         masked_data, min_max=(valid_min, valid_max), colormap="RdYlBu"
     )
     return arr

--- a/community/sina/NLCD_Tile_Example/NLCD_Tile_Example.py
+++ b/community/sina/NLCD_Tile_Example/NLCD_Tile_Example.py
@@ -4,8 +4,8 @@ def udf(bounds: fused.types.Bounds=[-121.673,37.561,-120.778,38.314], year:int=1
     from utils import get_data, get_summary
 
     # convert bounds to tile
-    common_utils = fused.load("https://github.com/fusedio/udfs/tree/36f4e97/public/common/").utils
-    tile = common_utils.get_tiles(bounds, clip=True)
+    common = fused.load("https://github.com/fusedio/udfs/tree/36f4e97/public/common/").utils
+    tile = common.get_tiles(bounds, clip=True)
 
     
     data = get_data(tile, year, land_type, chip_len)

--- a/community/sina/NLCD_Tile_Example/utils.py
+++ b/community/sina/NLCD_Tile_Example/utils.py
@@ -1,9 +1,9 @@
-utils = fused.load('https://github.com/fusedio/udfs/tree/e1fefb7/public/common/').utils
+common = fused.load("https://github.com/fusedio/udfs/tree/e1fefb7/public/common/").utils
 
 def get_data(bounds, year, land_type, chip_len):
         # source: https://www.mrlc.gov/downloads/sciweb1/shared/mrlc/data-bundles/Annual_NLCD_LndCov_{year}_CU_C1V0.tif
         path = f"s3://fused-asset/data/nlcd/Annual_NLCD_LndCov_{year}_CU_C1V0.tif"
-        tiff = utils.read_tiff(bounds, path, output_shape=(chip_len, chip_len), return_colormap=True)
+        tiff = common.read_tiff(bounds, path, output_shape=(chip_len, chip_len), return_colormap=True)
         if tiff is None:
             return None
         arr_int, metadata = tiff

--- a/community/sina/NLCD_Tile_Hexify/NLCD_Tile_Hexify.py
+++ b/community/sina/NLCD_Tile_Hexify/NLCD_Tile_Hexify.py
@@ -1,5 +1,5 @@
 nlcd_example_utils = fused.load('https://github.com/fusedio/udfs/tree/1b2b7e3/public/NLCD_Tile_Example/').utils
-common_utils = fused.load("https://github.com/fusedio/udfs/tree/36f4e97/public/common/").utils
+common = fused.load("https://github.com/fusedio/udfs/tree/36f4e97/public/common/").utils
 
 @fused.udf
 def udf(bounds: fused.types.Bounds=[-121.673,37.561,-120.778,38.314], year: int=1985, land_type: str='', chip_len: int=256):
@@ -7,7 +7,7 @@ def udf(bounds: fused.types.Bounds=[-121.673,37.561,-120.778,38.314], year: int=
     import pandas as pd
 
     # convert bounds to tile
-    tile = common_utils.get_tiles(bounds, clip=True)
+    tile = common.get_tiles(bounds, clip=True)
 
     #initial parameters
     x, y, z = tile.iloc[0][["x", "y", "z"]]
@@ -23,7 +23,7 @@ def udf(bounds: fused.types.Bounds=[-121.673,37.561,-120.778,38.314], year: int=
     arr_int, color_map = data
 
     # hexify tiff array
-    df = common_utils.arr_to_h3(arr_int, bounds, res=res, ordered=False)
+    df = common.arr_to_h3(arr_int, bounds, res=res, ordered=False)
 
     # find most frequet land_type
     df['most_freq'] = df.agg_data.map(lambda x: np.unique(x, return_counts=True)[0][np.argmax(np.unique(x, return_counts=True)[1])])

--- a/community/sina/NWS_Hazards_H3/NWS_Hazards_H3.py
+++ b/community/sina/NWS_Hazards_H3/NWS_Hazards_H3.py
@@ -8,8 +8,8 @@ def udf(bounds: fused.types.Bounds = [-113.334,22.124,-76.388,52.627], crs="EPSG
     from utils import fetch_all_features, add_rgb_cmap, CMAP
 
     # convert bounds to tile
-    common_utils = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
-    tile = common_utils.get_tiles(bounds, clip=True)
+    common = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
+    tile = common.get_tiles(bounds, clip=True)
 
     # Generate ESRI-friendly envelope bounds
     total_bounds = tile.geometry.total_bounds

--- a/community/sina/OakRidge_Overture_Buildings/OakRidge_Overture_Buildings.py
+++ b/community/sina/OakRidge_Overture_Buildings/OakRidge_Overture_Buildings.py
@@ -2,17 +2,17 @@
 def udf(bounds: fused.types.Bounds = [-122.432,37.800,-122.430,37.802]):
     import geopandas as gpd
     # Load pinned versions of utility functions.
-    common_utils = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
+    common = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
     overture_utils = fused.load("https://github.com/fusedio/udfs/tree/ee9bec5/public/Overture_Maps_Example/").utils # Load pinned versions of utility functions.
 
     # Convert bounds to tile
-    tile = common_utils.get_tiles(bounds, clip=True)
+    tile = common.get_tiles(bounds, clip=True)
 
     # 1. Load Overture Buildings
     gdf_overture = overture_utils.get_overture(bbox=tile)
 
     # 2. Load Oak Ridge Buildings
-    gdf_oakridge = common_utils.table_to_tile(
+    gdf_oakridge = common.table_to_tile(
         tile, table="s3://fused-asset/infra/building_oak_states/state=ca/", min_zoom=10
     )
 

--- a/community/sina/Ookla_Download_Speeds/Ookla_Download_Speeds.py
+++ b/community/sina/Ookla_Download_Speeds/Ookla_Download_Speeds.py
@@ -2,14 +2,14 @@
 def udf(bounds: fused.types.Bounds = [-92.317,-64.329,116.124,79.475]):
 
     # Load pinned versions of utility functions.
-    utils = fused.load("https://github.com/fusedio/udfs/tree/bb712a5/public/common/").utils
-    zoom = utils.estimate_zoom(bounds)
+    common = fused.load("https://github.com/fusedio/udfs/tree/bb712a5/public/common/").utils
+    zoom = common.estimate_zoom(bounds)
 
     file_path='s3://ookla-open-data/parquet/performance/type=mobile/year=2024/quarter=3/2024-07-01_performance_mobile_tiles.parquet'
 
     @fused.cache
     def get_data(bounds, file_path, h3_size):
-        con = utils.duckdb_connect()
+        con = common.duckdb_connect()
 
         # DuckDB query to:
         # 1. Convert lat/long to H3 cells

--- a/community/sina/Ookla_Download_Speeds_lat_lon_speed/Ookla_Download_Speeds_lat_lon_speed.py
+++ b/community/sina/Ookla_Download_Speeds_lat_lon_speed/Ookla_Download_Speeds_lat_lon_speed.py
@@ -4,7 +4,7 @@ def udf(bounds: fused.types.Bounds=[-92.317,-64.329,116.124,79.475], lat: float=
     file_path='s3://ookla-open-data/parquet/performance/type=mobile/year=2024/quarter=3/2024-07-01_performance_mobile_tiles.parquet'
     
     # Load pinned versions of utility functions.
-    utils = fused.load("https://github.com/fusedio/udfs/tree/ee9bec5/public/common/").utils
+    common = fused.load("https://github.com/fusedio/udfs/tree/ee9bec5/public/common/").utils
     
     # Sample usage: Set default lat/lon for San Francisco if none provided
     if lat is None and lon is None and bounds is None:
@@ -25,7 +25,7 @@ def udf(bounds: fused.types.Bounds=[-92.317,-64.329,116.124,79.475], lat: float=
     
     @fused.cache
     def get_data(total_bounds, file_path, h3_size):
-        con = utils.duckdb_connect()
+        con = common.duckdb_connect()
         # DuckDB query to:
         # 1. Convert lat/long to H3 cells
         # 2. Calculate average download speed per cell
@@ -52,7 +52,7 @@ def udf(bounds: fused.types.Bounds=[-92.317,-64.329,116.124,79.475], lat: float=
     
     # For point queries, find the closest H3 cell and return its speed
     if using_point_query:
-        con = utils.duckdb_connect()
+        con = common.duckdb_connect()
         
         # Convert the input lat/lon to an H3 cell
         point_cell_query = f'''

--- a/community/sina/Overture_East_Asian_Buildings_IOU/Overture_East_Asian_Buildings_IOU.py
+++ b/community/sina/Overture_East_Asian_Buildings_IOU/Overture_East_Asian_Buildings_IOU.py
@@ -5,14 +5,14 @@ def udf(bounds: fused.types.Bounds = [121.460,31.228,121.463,31.231], res=14):
 
     # Load pinned versions of utility functions.
     overture_utils = fused.load("https://github.com/fusedio/udfs/tree/99dbfec/public/Overture_Maps_Example/").utils
-    utils = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
+    common = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
 
     # convert bounds to tile
-    tile = utils.get_tiles(bounds, clip=True)
+    tile = common.get_tiles(bounds, clip=True)
 
     # 1. Load East Asia Zenodo Buildings
     path = "s3://fused-asset/misc/jennings/East_Asian_buildings_parquet3_ingested_3dec/"
-    gdf_zenodo = utils.table_to_tile(bounds, table=path)
+    gdf_zenodo = common.table_to_tile(bounds, table=path)
     print("Bulding Count EA: ", len(gdf_zenodo))
 
     # 2. Load Overture Buildings

--- a/community/sina/Overture_H3_Skyline/Overture_H3_Skyline.py
+++ b/community/sina/Overture_H3_Skyline/Overture_H3_Skyline.py
@@ -4,13 +4,13 @@ def udf(bounds: fused.types.Bounds = [-122.437,37.772,-122.404,37.799], h3_size:
 
     # Load pinned versions of utility functions.
     overture_utils = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/Overture_Maps_Example/").utils
-    utils = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
+    common = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
 
     # convert bounds to tile
-    tile = utils.get_tiles(bounds, clip=True)
+    tile = common.get_tiles(bounds, clip=True)
 
 
-    conn = utils.duckdb_connect()
+    conn = common.duckdb_connect()
 
     # 1. Set H3 resolution
     x, y, z = tile.iloc[0][["x", "y", "z"]]

--- a/community/sina/Overture_Maps_from_lat_lon_buffer/utils.py
+++ b/community/sina/Overture_Maps_from_lat_lon_buffer/utils.py
@@ -21,8 +21,8 @@ def get_overture(
     from shapely.geometry import shape, box
 
     # Load Fused helper functions
-    utils = fused.load(
-        "https://github.com/fusedio/udfs/tree/d0e8eb0/public/common/"
+    common = fused.load(
+    "https://github.com/fusedio/udfs/tree/d0e8eb0/public/common/"
     ).utils
 
     if release == "2024-02-15-alpha-0":
@@ -113,7 +113,7 @@ def get_overture(
     def get_part(part):
         part_path = f"{table_path}/part={part}/" if num_parts != 1 else table_path
         try:
-            return utils.table_to_tile(
+            return common.table_to_tile(
                 bbox, table=part_path, use_columns=use_columns, min_zoom=min_zoom
             )
         except ValueError:

--- a/community/sina/Overture_Nsi/Overture_Nsi.py
+++ b/community/sina/Overture_Nsi/Overture_Nsi.py
@@ -5,8 +5,8 @@ def udf(bounds: fused.types.Bounds = [-123.864,46.175,-123.832,46.199], join_wit
     import requests
 
     # convert bounds to tile
-    utils = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
-    tile = utils.get_tiles(bounds, clip=True)
+    common = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
+    tile = common.get_tiles(bounds, clip=True)
 
     if tile.iloc[0].z < 10:
         return None

--- a/community/sina/Overture_OakRidge_Comparison/Overture_OakRidge_Comparison.py
+++ b/community/sina/Overture_OakRidge_Comparison/Overture_OakRidge_Comparison.py
@@ -9,10 +9,10 @@ def udf(
 
     # Load pinned versions of utility functions.
     overture_utils = fused.load("https://github.com/fusedio/udfs/tree/2f138dd/public/Overture_Maps_Example/").utils
-    common_utils = fused.load("https://github.com/fusedio/udfs/tree/2f138dd/public/common/").utils
+    common = fused.load("https://github.com/fusedio/udfs/tree/2f138dd/public/common/").utils
 
 
-    conn = common_utils.duckdb_connect()
+    conn = common.duckdb_connect()
 
     if class_source=='Overture':
         metric = 'subtype'
@@ -25,7 +25,7 @@ def udf(
     gdf_overture = overture_utils.get_overture(bounds=bounds)
 
     # 2. Load Oak Ridge Buildings
-    gdf_oakridge = common_utils.table_to_tile(
+    gdf_oakridge = common.table_to_tile(
         bounds,
         table="s3://fused-asset/infra/building_oak/",
         use_columns=None,

--- a/community/sina/Overture_Places_Embedding_Clusters/Overture_Places_Embedding_Clusters.py
+++ b/community/sina/Overture_Places_Embedding_Clusters/Overture_Places_Embedding_Clusters.py
@@ -106,8 +106,8 @@ def udf(bounds: fused.types.Bounds = None, h3_size=8):
     from utils import global_categories
 
     # convert bounds to tile
-    utils = fused.load("https://github.com/fusedio/udfs/tree/bb712a5/public/common/").utils
-    tile = utils.get_tiles(bounds, clip=True) if bounds is not None else aoi
+    common = fused.load("https://github.com/fusedio/udfs/tree/bb712a5/public/common/").utils
+    tile = common.get_tiles(bounds, clip=True) if bounds is not None else aoi
 
     # 1. Polyfill AOI
     h3s = h3.polygon_to_cells(h3.geo_to_h3shape(tile.geometry.iloc[0]), h3_size)
@@ -125,7 +125,7 @@ def udf(bounds: fused.types.Bounds = None, h3_size=8):
             print(e)
 
     # 2. Run Embeddings UDF for each H3 cell
-    gdfs = utils.run_pool(run_udfs, h3s, max_workers=100)
+    gdfs = common.run_pool(run_udfs, h3s, max_workers=100)
     # Filter out failed outputs
     gdfs = [gdf for gdf in gdfs if gdf is not None]
     if len(gdfs) == 0:

--- a/community/sina/PC_Sentinel2/PC_Sentinel2.py
+++ b/community/sina/PC_Sentinel2/PC_Sentinel2.py
@@ -12,8 +12,8 @@ def udf(
     from pystac.extensions.eo import EOExtension as eo
 
     # convert bounds to tile
-    utils = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
-    tile = utils.get_tiles(bounds, clip=True)
+    common = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
+    tile = common.get_tiles(bounds, clip=True)
 
     odc.stac.configure_s3_access(requester_pays=True)
 

--- a/community/sina/Pool_Runner/Pool_Runner.py
+++ b/community/sina/Pool_Runner/Pool_Runner.py
@@ -7,9 +7,9 @@ param_json = param_list[0]
 def udf(param_list: dict = param_list):
     import pandas as pd
     # Load pinned versions of utility functions.
-    utils = fused.load("https://github.com/fusedio/udfs/tree/ee9bec5/public/common/").utils
+    common = fused.load("https://github.com/fusedio/udfs/tree/ee9bec5/public/common/").utils
     df = fused.run(udf_nail, engine='realtime')
-    output = utils.run_pool(lambda x:fused.run(udf_nail,param_json=x, 
+    output = common.run_pool(lambda x:fused.run(udf_nail,param_json=x, 
                                                             engine='local'), param_list)
     df = pd.concat(output)
     print(df)

--- a/community/sina/Power_Plants_h3/Power_Plants_H3.py
+++ b/community/sina/Power_Plants_h3/Power_Plants_H3.py
@@ -5,8 +5,8 @@ def udf(bounds: fused.types.Bounds=[-49.108,-35.500,72.922,67.364]):
     from utils import add_rgb_cmap, CMAP, get_data, run_query
 
     # convert bounds to tile
-    utils = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
-    tile = utils.get_tiles(bounds, clip=True)
+    common = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
+    tile = common.get_tiles(bounds, clip=True)
     zoom = tile.iloc[0].z
     
     # This is the line that caculates the resolution based on zoom. You can overide the resolution parameter by hard coding it.

--- a/community/sina/Power_Plants_h3/utils.py
+++ b/community/sina/Power_Plants_h3/utils.py
@@ -37,9 +37,11 @@ def run_query(bounds, pplant_table, resolution):
     
         """
         # Load pinned versions of utility functions.
-        utils = fused.load("https://github.com/fusedio/udfs/tree/ee9bec5/public/common/").utils
+        common = fused.load(
+        "https://github.com/fusedio/udfs/tree/ee9bec5/public/common/"
+        ).utils
         # Connect to DuckDB
-        con = utils.duckdb_connect()
+        con = common.duckdb_connect()
 
         # Execute the query and get the DataFrame
         return con.sql(query, params={'xmin': xmin, 'xmax': xmax, 'ymin': ymin, "ymax": ymax, 'resolution': resolution}).df()

--- a/community/sina/Reprojection_Example/Reprojection_Example.py
+++ b/community/sina/Reprojection_Example/Reprojection_Example.py
@@ -9,7 +9,7 @@ def udf(path:str = f"s3://fused-asset/data/cdls/2022_30m_cdls.tif",
         fused_metadata:dict={}, 
         verbose:bool=True):
     from utils import transform_to_gdf, reproject_bounds_shape, reproject_transform_crs, reproject_crs_shape
-    utils = fused.load("https://github.com/fusedio/udfs/tree/fd32f9c/public/common/").utils
+    common = fused.load("https://github.com/fusedio/udfs/tree/fd32f9c/public/common/").utils
     if not crs:
         crs='4326'
     ############ read_tiff (raw pixels) ########### 
@@ -17,7 +17,7 @@ def udf(path:str = f"s3://fused-asset/data/cdls/2022_30m_cdls.tif",
     import shapely
     bbox = gpd.GeoDataFrame(geometry=[shapely.box(*bounds)], crs=crs)
     # bbox = gpd.GeoDataFrame(geometry=[shapely.box(-120.53035513070277,37.98012159397518,-120.41893689940078,38.03204439357735)], crs=4326)
-    arr, metadata = utils.read_tiff(bbox, path, output_shape=None, return_colormap=False, return_transform=True, return_crs=True, return_bounds=True, return_meta=True,)
+    arr, metadata = common.read_tiff(bbox, path, output_shape=None, return_colormap=False, return_transform=True, return_crs=True, return_bounds=True, return_meta=True,)
     if verbose:
         print(metadata["meta"])
         print(arr.shape)

--- a/community/sina/Reprojection_Example/utils.py
+++ b/community/sina/Reprojection_Example/utils.py
@@ -4,11 +4,11 @@
 
 def transform_to_gdf(transform, shape, crs):
     import rasterio
-    utils = fused.load(
-        "https://github.com/fusedio/udfs/tree/fd32f9c/public/common/"
+    common = fused.load(
+    "https://github.com/fusedio/udfs/tree/fd32f9c/public/common/"
     ).utils
     bounds = rasterio.transform.array_bounds(shape[-2], shape[-1], transform)
-    return utils.bounds_to_gdf(bounds, crs=crs)
+    return common.bounds_to_gdf(bounds, crs=crs)
 
 def reproject_bounds_shape(arr, src_crs, src_bounds, dst_crs, dst_bounds, dst_shape=(256, 256)):
     import rasterio

--- a/community/sina/S2_explorer/S2_explorer.py
+++ b/community/sina/S2_explorer/S2_explorer.py
@@ -25,8 +25,8 @@ def udf(
     from PIL import Image
 
     # Load pinned versions of utility functions.
-    utils = fused.load("https://github.com/fusedio/udfs/tree/bb712a5/public/common/").utils
-    zoom = utils.estimate_zoom(bounds)
+    common = fused.load("https://github.com/fusedio/udfs/tree/bb712a5/public/common/").utils
+    zoom = common.estimate_zoom(bounds)
 
     # This is the line that caculates the resolution based on zoom. You can overide the resolution parameter by hard coding it.
     resolution = max(min(int(6 + (zoom - 10) * (5/9)), 11), 0)

--- a/community/sina/Satellite_Greenest_Pixel/Satellite_Greenest_Pixel.py
+++ b/community/sina/Satellite_Greenest_Pixel/Satellite_Greenest_Pixel.py
@@ -61,8 +61,8 @@ def udf(
     )
 
     # convert bounds to tile
-    utils = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
-    tile = utils.get_tiles(bounds, clip=True)
+    common = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
+    tile = common.get_tiles(bounds, clip=True)
 
     collection, band_list, time_of_interest, query, scale = json.loads(
         collection_params

--- a/community/sina/Satellite_Greenest_Pixel/utils.py
+++ b/community/sina/Satellite_Greenest_Pixel/utils.py
@@ -8,7 +8,7 @@ def run_pool_tiffs(bounds, df_tiffs, output_shape):
     def fn_read_tiff(tiff_url, bounds=bounds, output_shape=output_shape):
         read_tiff = fused.load(
             "https://github.com/fusedio/udfs/tree/eda5aec/public/common/"
-        ).utils.read_tiff
+        ).common.read_tiff
         return read_tiff(bounds, tiff_url, output_shape=output_shape)
 
     tiff_list = []
@@ -17,9 +17,11 @@ def run_pool_tiffs(bounds, df_tiffs, output_shape):
             tiff_list.append(df_tiffs[band].iloc[i])
 
     # Load pinned versions of utility functions.
-    utils = fused.load("https://github.com/fusedio/udfs/tree/ee9bec5/public/common/").utils
+    common = fused.load(
+    "https://github.com/fusedio/udfs/tree/eda5aec/public/common/"
+    ).utils
 
-    arrs_tmp = utils.run_pool(fn_read_tiff, tiff_list)
+    arrs_tmp = common.run_pool(fn_read_tiff, tiff_list)
     arrs_out = np.stack(arrs_tmp)
     arrs_out = arrs_out.reshape(len(columns), len(df_tiffs), output_shape[-2], output_shape[-1])
     return arrs_out

--- a/community/sina/Sentinel1_Tile_Example/Sentinel1_Tile_Example.py
+++ b/community/sina/Sentinel1_Tile_Example/Sentinel1_Tile_Example.py
@@ -79,7 +79,7 @@ def udf(time_of_interest="2024-10-01/2024-12-10"):
     image=stacked_image.std(axis=0)
     print(image.shape)
     # return (image).astype('uint8'), bounds.total_bounds
-    utils = fused.load(
+    common = fused.load(
     "https://github.com/fusedio/udfs/tree/2b25cb3/public/common/"
     ).utils
-    return utils.arr_to_plasma(image), bounds.total_bounds
+    return common.arr_to_plasma(image), bounds.total_bounds

--- a/community/sina/Sentinel_Tile_Example/Sentinel_Tile_Example.py
+++ b/community/sina/Sentinel_Tile_Example/Sentinel_Tile_Example.py
@@ -15,8 +15,8 @@ def udf(
     import utils
 
     # convert bounds to tile
-    common_utils = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
-    tile = common_utils.get_tiles(bounds, clip=True)
+    common = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
+    tile = common.get_tiles(bounds, clip=True)
     zoom = tile.iloc[0].z
     
     if provider == "AWS":
@@ -63,7 +63,7 @@ def udf(
         print(ndvi.shape)
         arr = ndvi.max(dim="time")
         
-        rgb_image = common_utils.visualize(
+        rgb_image = common.visualize(
             data=arr,
             min=0,
             max=1,

--- a/community/sina/Simple_Trips_Gen_Lima/Simple_Trips_Gen_Lima.py
+++ b/community/sina/Simple_Trips_Gen_Lima/Simple_Trips_Gen_Lima.py
@@ -1,11 +1,11 @@
-import geopandas as gpd
-from shapely.geometry import box
-from datetime import datetime, timedelta
 
+from shapely.geometry import box
 aoi = gpd.GeoDataFrame({'geometry': [box(*[-77.0685986328125, -12.055065023002463, -77.04211914062499, -12.032977469134593])]}).set_crs('EPSG:4326', allow_override=True)
 
 @fused.udf
 def udf(
+    import geopandas as gpd
+    from datetime import datetime, timedelta
     aoi: gpd.GeoDataFrame = aoi,
     start_hour: str = datetime.now(), 
     end_hour: str = datetime.now() + timedelta(hours=15),

--- a/community/sina/Solar_Induced_Fluorescence/Solar_Induced_Fluorescence.py
+++ b/community/sina/Solar_Induced_Fluorescence/Solar_Induced_Fluorescence.py
@@ -5,8 +5,8 @@ def udf(bounds: fused.types.Bounds=[-143.184,7.090,-39.292,61.808], year: str = 
     import pandas as pd
 
     # convert bounds to tile
-    utils = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
-    tile = utils.get_tiles(bounds, clip=True)
+    common = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
+    tile = common.get_tiles(bounds, clip=True)
     
     # Dynamically construct the path based on the year and month
     path = f's3://soldatanasasifglobalifoco2modis1863/Global_SIF_OCO2_MODIS_1863/data/sif_ann_{year}{month}{period}.nc'
@@ -33,7 +33,7 @@ def udf(bounds: fused.types.Bounds=[-143.184,7.090,-39.292,61.808], year: str = 
 
     # Convert the array to an image with the specified colormap
     img = (arr_aoi * 255).astype('uint8')
-    img = utils.arr_to_plasma(arr_aoi, min_max=(0, 1), colormap="rainbow", include_opacity=False, reverse=False)
+    img = common.arr_to_plasma(arr_aoi, min_max=(0, 1), colormap="rainbow", include_opacity=False, reverse=False)
 
     return img
 

--- a/community/sina/Solar_Irradiance/Solar_Irradiance.py
+++ b/community/sina/Solar_Irradiance/Solar_Irradiance.py
@@ -1,8 +1,8 @@
-import geopandas as gpd
-from shapely import box
 
 @fused.udf
 def udf(
+    import geopandas as gpd
+    from shapely import box
     bounds: fused.types.Bounds = [-122.549, 37.681, -122.341, 37.818]
 ):
     import palettable

--- a/community/sina/Solar_Irradiance/utils.py
+++ b/community/sina/Solar_Irradiance/utils.py
@@ -1,8 +1,6 @@
 # Load utility functions.
-common_utils = fused.load(
-    "https://github.com/fusedio/udfs/tree/5cfb808/public/common/"
-).utils
+common = fused.load("https://github.com/fusedio/udfs/tree/5cfb808/public/common/").utils
 
 # Pick particular functions that will be used in this UDF.
-visualize = common_utils.visualize
-read_tiff = common_utils.read_tiff
+visualize = common.visualize
+read_tiff = common.read_tiff

--- a/community/sina/Vegetation_Segmentation/Vegetation_Segmentation.py
+++ b/community/sina/Vegetation_Segmentation/Vegetation_Segmentation.py
@@ -11,8 +11,8 @@ def udf(
     from utils import process_image, url_to_arr
 
     # convert bounds to tile
-    common_utils = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
-    tile = common_utils.get_tiles(bounds, target_num_tiles=1)
+    common = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
+    tile = common.get_tiles(bounds, target_num_tiles=1)
     
     # Get the bounding box coordinates
     x, y, z = tile[["x", "y", "z"]].iloc[0]

--- a/community/sina/Watershed_Boundery_US/Watershed_Boundery_US.py
+++ b/community/sina/Watershed_Boundery_US/Watershed_Boundery_US.py
@@ -1,6 +1,6 @@
 @fused.udf
 def udf(bounds: fused.types.Bounds = [-74.519,40.340,-73.034,41.120], path:str='s3://fused-asset/infra/hydro_wbdhu12_us'):
     # Load pinned versions of utility functions.
-    utils = fused.load("https://github.com/fusedio/udfs/tree/d0e8eb0/public/common/").utils
-    df = utils.table_to_tile(bounds, path, min_zoom=9, use_columns=['huc12', 'name', 'hutype'])
+    common = fused.load("https://github.com/fusedio/udfs/tree/d0e8eb0/public/common/").utils
+    df = common.table_to_tile(bounds, path, min_zoom=9, use_columns=['huc12', 'name', 'hutype'])
     return df 

--- a/community/sina/Zonal_Stats_Forest_Obs_Runner/Zonal_Stats_Forest_Obs_Runner.py
+++ b/community/sina/Zonal_Stats_Forest_Obs_Runner/Zonal_Stats_Forest_Obs_Runner.py
@@ -17,7 +17,7 @@ def udf(
     import itertools
 
     # Load pinned versions of utility functions.
-    utils = fused.load("https://github.com/fusedio/udfs/tree/ee9bec5/public/common/").utils
+    common = fused.load("https://github.com/fusedio/udfs/tree/ee9bec5/public/common/").utils
     zonal_utils = fused.load("https://github.com/fusedio/udfs/tree/ee9bec5/community/plinio/Zonal_Stats_Forest_Obs/").utils
 
     # 1. Define `cell_id` from the input dictionary
@@ -57,7 +57,7 @@ def udf(
         translate = True
 
     # 3. Create gdf_muni
-    gdf_muni = utils.table_to_tile(
+    gdf_muni = common.table_to_tile(
         gdf_cell,
         table_muni_geoboundaries,
         use_columns=["shapeID", "geometry"],
@@ -78,7 +78,7 @@ def udf(
     # 4. Load tiff
     filename = gdf_cell[["url"]].iloc[0].values[0]
     tiff_url = f"s3://fused-asset/gfc2020/{filename}"
-    geom_bounds_muni = utils.geo_bbox(gdf_muni).geometry[0]
+    geom_bounds_muni = common.geo_bbox(gdf_muni).geometry[0]
 
     # 5. Get TIFF dataset
     da, _ = zonal_utils.rio_clip_geom_from_url(geom_bounds_muni, tiff_url)

--- a/community/sina/Zonal_Stats_Forest_Obs_Viewer/Zonal_Stats_Forest_Obs_Viewer.py
+++ b/community/sina/Zonal_Stats_Forest_Obs_Viewer/Zonal_Stats_Forest_Obs_Viewer.py
@@ -4,8 +4,8 @@ def udf(bounds: fused.types.Bounds=[7.872,46.906,7.886,46.913]):
     import geopandas as gpd
 
     # convert bounds to tile
-    common_utils = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
-    tile = common_utils.get_tiles(bounds, clip=True)
+    common = fused.load("https://github.com/fusedio/udfs/tree/2f41ae1/public/common/").utils
+    tile = common.get_tiles(bounds, clip=True)
 
     zonal_utils = fused.load("https://github.com/fusedio/udfs/tree/ee9bec5/community/plinio/Zonal_Stats_Forest_Obs/").utils
 

--- a/community/sina/download_images_for_bbox_arcgis_imageserver_rest/download_images_for_bbox_arcgis_imageserver_rest.py
+++ b/community/sina/download_images_for_bbox_arcgis_imageserver_rest/download_images_for_bbox_arcgis_imageserver_rest.py
@@ -42,7 +42,7 @@ def udf(
     from utils import bounds_fused_to_gdf, get_urls_from_arcgis_imageserver_rest
 
     if (bounds is not None) & (bbox_gpkg_path is None):
-        utils = fused.load(
+        common = fused.load(
             "https://github.com/fusedio/udfs/tree/e74035a1/public/common/"
         ).utils
         bounds_gdf = bounds_fused_to_gdf(bounds)

--- a/community/sina/vancouver_crime_url_or_data_yearly/vancouver_crime_url_or_data_yearly.py
+++ b/community/sina/vancouver_crime_url_or_data_yearly/vancouver_crime_url_or_data_yearly.py
@@ -1,7 +1,7 @@
-from typing import Literal
 
 @fused.udf
 def udf(
+    from typing import Literal
     output_format: Literal['data', 'chart-url'] = 'data',
     analysis_start_year: int = 2021, 
     lat: float=49.2806, 

--- a/community/sindhu/Placekey_DOL-violations_NPI/utils.py
+++ b/community/sindhu/Placekey_DOL-violations_NPI/utils.py
@@ -7,14 +7,16 @@ def placekey_df_validate(df):
 
 @fused.cache
 def get_placekeyd_dataset(bbox, name: str):
-    utils = fused.load('https://github.com/fusedio/udfs/tree/19b5240/public/common/').utils
+    common = fused.load(
+    "https://github.com/fusedio/udfs/tree/19b5240/public/common/"
+    ).utils
     # pick one of these datasets!!
     datasets = set(['dc-healthy-corner-stores','home-health-agency-medicare-enrollments', 'home-infusion-therapy-provider-medicare-enrollments', 'hospice-medicare-enrollments', 'hospital-medicare-enrollments', 'national-downloadable-files-from-the-doctors-and-clinicians-data-section', 'skilled-nursing-facility-medicare-enrollments', 'rural-health-clinic-medicare-enrollments',
                    'national-provider-identifier', 'department-of-labor-wage-and-hour-compliance'])
     if name in datasets:
         path = 's3://placekey-free-datasets/'+name+'/fused/_sample'
         base_path = path.rsplit('/', maxsplit=1)[0] if path.endswith('/_sample') or path.endswith('/_metadata') else path
-        return utils.table_to_tile(bbox, table=base_path, use_columns=None)
+        return common.table_to_tile(bbox, table=base_path, use_columns=None)
     else:
         raise ValueError(name + " is either not available through Placekey or is not onboarded onto fused.io. Contact Placekey if you would like it to be! https://www.placekey.io/contact-sales")    
 

--- a/community/sindhu/Placekey_HomeHealthAgency-MedicareEnrollments_x_NPI/utils.py
+++ b/community/sindhu/Placekey_HomeHealthAgency-MedicareEnrollments_x_NPI/utils.py
@@ -7,14 +7,16 @@ def placekey_df_validate(df):
 
 @fused.cache
 def get_placekeyd_dataset(bbox, name: str):
-    utils = fused.load('https://github.com/fusedio/udfs/tree/19b5240/public/common/').utils
+    common = fused.load(
+    "https://github.com/fusedio/udfs/tree/19b5240/public/common/"
+    ).utils
     # pick one of these datasets!!
     datasets = set(['dc-healthy-corner-stores','home-health-agency-medicare-enrollments', 'home-infusion-therapy-provider-medicare-enrollments', 'hospice-medicare-enrollments', 'hospital-medicare-enrollments', 'national-downloadable-files-from-the-doctors-and-clinicians-data-section', 'skilled-nursing-facility-medicare-enrollments', 'rural-health-clinic-medicare-enrollments',
                    'national-provider-identifier', 'department-of-labor-wage-and-hour-compliance'])
     if name in datasets:
         path = 's3://placekey-free-datasets/'+name+'/fused/_sample'
         base_path = path.rsplit('/', maxsplit=1)[0] if path.endswith('/_sample') or path.endswith('/_metadata') else path
-        return utils.table_to_tile(bbox, table=base_path, use_columns=None)
+        return common.table_to_tile(bbox, table=base_path, use_columns=None)
     else:
         raise ValueError(name + " is either not available through Placekey or is not onboarded onto fused.io. Contact Placekey if you would like it to be! https://www.placekey.io/contact-sales")    
 

--- a/community/yashbit/biogas_transportation/biogas_transportation.py
+++ b/community/yashbit/biogas_transportation/biogas_transportation.py
@@ -8,7 +8,7 @@ def udf(bbox: fused.types.Tile = None, n=10):
     import pandas as pd
     import shapely
 
-    utils = fused.load(
+    common = fused.load(
         "https://github.com/fusedio/udfs/tree/f928ee1/public/common/"
     ).utils
 


### PR DESCRIPTION
- Update all remote common utils imports to use 'common' instead of 'utils'
- Move all external imports inside UDF functions
- Remove unnecessary 'import fused' statements
- Standardize import structure across all community UDFs
