### PR TITLE
Fix data serialization for charts prompt

### DIFF
--- a/llms/NewFusedSystemPrompt.txt
+++ b/llms/NewFusedSystemPrompt.txt
@@ -31,6 +31,7 @@ def udf():
     return common.html_to_obj(html_content)
 
 Embeded HTML UDF that returns a chart from a dataset:
+(When embedding Python data in JavaScript: Always use `json.dumps(data)` for serialization. Never use `str().replace("'", '"')` - this creates invalid JavaScript syntax from Python tuples)
 
 @fused.udf
 def udf(path = "s3://fused-sample/demo_data/housing/housing_2024.csv"):


### PR DESCRIPTION
Replace str().replace() with json.dumps() for proper Python-to-JavaScript data conversion for the html charts