### PR TITLE
UTF-8 Error prompt update

### DIFF
--- a/llms/BuildChartPrompt.txt
+++ b/llms/BuildChartPrompt.txt
@@ -221,6 +221,7 @@ If you lack knowledge about something after you've used available resources and 
 File Handling:
 You do not need to use s3fs to save files to S3. Fused Workbench already has access to S3. So doing df.to_parquet(s3://.../file.pq) should be enough.
 To read files in S3 you can use fused.api.list(). This returns: "list[str]". This is a list of the full paths to files (example: "s3://fused-sample/demo_data/timeseries/2005.pq"). Wrap this into a df to get all the files paths available
+When reading CSV files, always wrap in a try/except to handle encodings. First try encoding="utf-8", and on UnicodeDecodeError retry with encoding="latin1"
 
 Performance & Optimization:
 UDF are run many times as users iterate. We don't want to waste time on redoing operations that were already done like opening files or doing heavy processing. Any processing that takes more than 0.2s should be wrapped in a function and get the @fused.cache decorator

--- a/llms/BuildChartPrompt.txt
+++ b/llms/BuildChartPrompt.txt
@@ -221,7 +221,7 @@ If you lack knowledge about something after you've used available resources and 
 File Handling:
 You do not need to use s3fs to save files to S3. Fused Workbench already has access to S3. So doing df.to_parquet(s3://.../file.pq) should be enough.
 To read files in S3 you can use fused.api.list(). This returns: "list[str]". This is a list of the full paths to files (example: "s3://fused-sample/demo_data/timeseries/2005.pq"). Wrap this into a df to get all the files paths available
-When reading CSV files fails, use encoding="utf-8", and on UnicodeDecodeError retry with encoding="latin1"
+When reading CSV files, use this robust pattern: try pd.read_csv(file, encoding="utf-8") first, then on UnicodeDecodeError try encoding="utf-8-sig", then "latin1", then "cp1252". Add on_bad_lines='skip' to skip malformed rows.
 
 Performance & Optimization:
 UDF are run many times as users iterate. We don't want to waste time on redoing operations that were already done like opening files or doing heavy processing. Any processing that takes more than 0.2s should be wrapped in a function and get the @fused.cache decorator

--- a/llms/BuildChartPrompt.txt
+++ b/llms/BuildChartPrompt.txt
@@ -221,7 +221,7 @@ If you lack knowledge about something after you've used available resources and 
 File Handling:
 You do not need to use s3fs to save files to S3. Fused Workbench already has access to S3. So doing df.to_parquet(s3://.../file.pq) should be enough.
 To read files in S3 you can use fused.api.list(). This returns: "list[str]". This is a list of the full paths to files (example: "s3://fused-sample/demo_data/timeseries/2005.pq"). Wrap this into a df to get all the files paths available
-When reading CSV files, always wrap in a try/except to handle encodings. First try encoding="utf-8", and on UnicodeDecodeError retry with encoding="latin1"
+When reading CSV files fails, use encoding="utf-8", and on UnicodeDecodeError retry with encoding="latin1"
 
 Performance & Optimization:
 UDF are run many times as users iterate. We don't want to waste time on redoing operations that were already done like opening files or doing heavy processing. Any processing that takes more than 0.2s should be wrapped in a function and get the @fused.cache decorator

--- a/llms/BuildCodePrompt.txt
+++ b/llms/BuildCodePrompt.txt
@@ -103,6 +103,7 @@ If you lack knowledge about something after you've used available resources and 
 File Handling:
 You do not need to use s3fs to save files to S3. Fused Workbench already has access to S3. So doing df.to_parquet(s3://.../file.pq) should be enough.
 To read files in S3 you can use fused.api.list(). This returns: "list[str]". This is a list of the full paths to files (example: "s3://fused-sample/demo_data/timeseries/2005.pq"). Wrap this into a df to get all the files paths available
+When reading CSV files, always wrap in a try/except to handle encodings. First try encoding="utf-8", and on UnicodeDecodeError retry with encoding="latin1"
 
 URL Reading & Web Content:
 You cannot open or read URLs directly but you SHOULD TRY TO OPEN URLS WITH PYTHON TOOLS

--- a/llms/BuildCodePrompt.txt
+++ b/llms/BuildCodePrompt.txt
@@ -103,7 +103,7 @@ If you lack knowledge about something after you've used available resources and 
 File Handling:
 You do not need to use s3fs to save files to S3. Fused Workbench already has access to S3. So doing df.to_parquet(s3://.../file.pq) should be enough.
 To read files in S3 you can use fused.api.list(). This returns: "list[str]". This is a list of the full paths to files (example: "s3://fused-sample/demo_data/timeseries/2005.pq"). Wrap this into a df to get all the files paths available
-When reading CSV files fails, use encoding="utf-8", and on UnicodeDecodeError retry with encoding="latin1"
+When reading CSV files, use this robust pattern: try pd.read_csv(file, encoding="utf-8") first, then on UnicodeDecodeError try encoding="utf-8-sig", then "latin1", then "cp1252". Add on_bad_lines='skip' to skip malformed rows.
 
 URL Reading & Web Content:
 You cannot open or read URLs directly but you SHOULD TRY TO OPEN URLS WITH PYTHON TOOLS

--- a/llms/BuildCodePrompt.txt
+++ b/llms/BuildCodePrompt.txt
@@ -103,7 +103,7 @@ If you lack knowledge about something after you've used available resources and 
 File Handling:
 You do not need to use s3fs to save files to S3. Fused Workbench already has access to S3. So doing df.to_parquet(s3://.../file.pq) should be enough.
 To read files in S3 you can use fused.api.list(). This returns: "list[str]". This is a list of the full paths to files (example: "s3://fused-sample/demo_data/timeseries/2005.pq"). Wrap this into a df to get all the files paths available
-When reading CSV files, always wrap in a try/except to handle encodings. First try encoding="utf-8", and on UnicodeDecodeError retry with encoding="latin1"
+When reading CSV files fails, use encoding="utf-8", and on UnicodeDecodeError retry with encoding="latin1"
 
 URL Reading & Web Content:
 You cannot open or read URLs directly but you SHOULD TRY TO OPEN URLS WITH PYTHON TOOLS


### PR DESCRIPTION
Why is this caused?
Pandas assumes that all text files are UTF-8 encoded Many different files from all over the web might use some different kind of encoding The added fix is a standard encoding error fix to find and replace any problematic characters while reading the CSV file,