### PR TITLE
Coerce or bind caller values that reach SQL and returned HTML

### DIFF
--- a/community/max/Hex_Tile_Map_Incidence/Hex_Tile_Map_Incidence.py
+++ b/community/max/Hex_Tile_Map_Incidence/Hex_Tile_Map_Incidence.py
@@ -10,7 +10,18 @@ def udf(
     zoom: float = 13,
     tooltip_columns: list = None,
 ):
+    import json as _json
     import pandas as pd
+
+    # These land inside a <script> block. Neither repr() nor the {x!r} conversion
+    # escapes "</script>", which closes the tag before the browser parses any JS.
+    def _js(value):
+        return _json.dumps(value).replace("</", "<\\/")
+
+    mapbox_token_js = _js(str(mapbox_token))
+    tile_url_template_js = _js(str(tile_url_template))
+    config_json_js = _js(str(config_json))
+    tooltip_columns_js = _js(list(tooltip_columns) if tooltip_columns else [])
     
     data_preview = pd.read_parquet("https://udf.ai/UDF_JP_intersection_accidents/run/tiles/15/29103/12900?dtype_out_raster=png&dtype_out_vector=parquet")
     print(data_preview.T)
@@ -86,11 +97,11 @@ def udf(
   </div>
 
   <script>
-    const MAPBOX_TOKEN = {mapbox_token!r};
+    const MAPBOX_TOKEN = {mapbox_token_js};
     const STYLE_URL    = "mapbox://styles/mapbox/dark-v10";
-    const TPL          = {tile_url_template!r};
-    const CONFIG       = JSON.parse({config_json!r});
-    const TOOLTIP_COLUMNS = {tooltip_columns if tooltip_columns else []!r};
+    const TPL          = {tile_url_template_js};
+    const CONFIG       = JSON.parse({config_json_js});
+    const TOOLTIP_COLUMNS = {tooltip_columns_js};
 
     const {{ TileLayer, PolygonLayer, MapboxOverlay }} = deck;
     const H3HexagonLayer = deck.H3HexagonLayer || (deck.GeoLayers && deck.GeoLayers.H3HexagonLayer);

--- a/community/max/era5_hex_mean_temp_foss4g/era5_hex_mean_temp_foss4g.py
+++ b/community/max/era5_hex_mean_temp_foss4g/era5_hex_mean_temp_foss4g.py
@@ -2,6 +2,13 @@
 def udf(month='2024-05',
     bounds:list=[-130, 25, -60, 50]
 ):
+    # month lands in the object path inside read_parquet(); keep it to YYYY-MM.
+    import re as _re
+    if not _re.fullmatch(r"\d{4}-\d{2}", str(month)):
+        raise ValueError(f"month must look like YYYY-MM, got {month!r}")
+    # bounds only guarantees four elements, not four numbers: coerce before
+    # they reach the query.
+    bounds = [float(v) for v in bounds]
     path = f's3://fused-asset/data/era5/t2m_daily_mean_v4_1000/month={month}/0.parquet'
     
     common = fused.load("https://github.com/fusedio/udfs/tree/3991434/public/common/")

--- a/community/max/nyc_dashboard_witt_ai/nyc_dashboard_witt_ai.py
+++ b/community/max/nyc_dashboard_witt_ai/nyc_dashboard_witt_ai.py
@@ -6,14 +6,14 @@ def udf(path: str = "s3://fused-sample/demo_data/nyc_taxi/yellow_tripdata_2025-0
     common = fused.load("https://github.com/fusedio/udfs/tree/3991434/public/common/")    
     con = common.duckdb_connect()
     
-    df = con.execute(f"""
+    df = con.execute("""
         SELECT 
             EXTRACT(hour FROM tpep_pickup_datetime) as pickup_hour,
             COUNT(*) as pickup_count
-        FROM read_parquet('{path}') 
+        FROM read_parquet(?) 
         GROUP BY EXTRACT(hour FROM tpep_pickup_datetime)
         ORDER BY pickup_hour
-    """).df()
+    """, [path]).df()
     
     data = df.to_dict('records')
     

--- a/community/milind/chart_js_generator/chart_js_generator.py
+++ b/community/milind/chart_js_generator/chart_js_generator.py
@@ -15,6 +15,13 @@ def udf(
   version: str = "4.4.1",
   device_pixel_ratio: float = 2.0,
 ):
+  # version picks the CDN script the page loads and background lands in CSS:
+  # keep both to a known-safe shape rather than passing them through.
+  import re as _re
+  if not _re.fullmatch(r"[0-9]+(\.[0-9]+)*", str(version)):
+      raise ValueError(f"version must be a dotted version number, got {version!r}")
+  if not _re.fullmatch(r"[A-Za-z0-9#(),.%\s-]{0,64}", str(background)):
+      raise ValueError(f"background must be a plain CSS colour, got {background!r}")
   import json
 
   try:

--- a/community/milind/ny411_noise_sample_h3/ny411_noise_sample_h3.py
+++ b/community/milind/ny411_noise_sample_h3/ny411_noise_sample_h3.py
@@ -11,12 +11,12 @@ def udf(
     SELECT
       h3_latlng_to_cell(lat, lng, {res}) AS hex,
       COUNT(*) AS cnt
-    FROM read_csv_auto('{noise_311_link}')
+    FROM read_csv_auto(?)
     WHERE lat IS NOT NULL AND lng IS NOT NULL
     GROUP BY 1
     """
 
-    df = con.sql(qr).df()
+    df = con.execute(qr, [noise_311_link]).df()
 
     # Debugging: print the resulting DataFrame schema
     print(df.T)

--- a/community/sina/Ookla_Download_Speeds/Ookla_Download_Speeds.py
+++ b/community/sina/Ookla_Download_Speeds/Ookla_Download_Speeds.py
@@ -3,6 +3,8 @@ def udf(bounds: fused.types.Bounds = [-92.317,-64.329,116.124,79.475]):
 
     # Load pinned versions of utility functions.
     common = fused.load("https://github.com/fusedio/udfs/tree/3991434/public/common/")
+    # bounds only guarantees four elements, not four numbers.
+    bounds = [float(v) for v in bounds]
     zoom = common.estimate_zoom(bounds)
 
     file_path='s3://ookla-open-data/parquet/performance/type=mobile/year=2024/quarter=3/2024-07-01_performance_mobile_tiles.parquet'

--- a/public/Basics_of_H3_in_Fused/era5_monthly_mean/era5_monthly_mean.py
+++ b/public/Basics_of_H3_in_Fused/era5_monthly_mean/era5_monthly_mean.py
@@ -2,6 +2,13 @@
 def udf(month='2024-05',
     bounds:fused.types.Bounds=[-130, 25, -60, 50]
 ):
+    # month lands in the object path inside read_parquet(); keep it to YYYY-MM.
+    import re as _re
+    if not _re.fullmatch(r"\d{4}-\d{2}", str(month)):
+        raise ValueError(f"month must look like YYYY-MM, got {month!r}")
+    # bounds only guarantees four elements, not four numbers: coerce before
+    # they reach the query.
+    bounds = [float(v) for v in bounds]
     path = f's3://fused-asset/data/era5/t2m_daily_mean_v4_1000/month={month}/0.parquet'
     
     common = fused.load("https://github.com/fusedio/udfs/tree/56ec615/public/common/")

--- a/public/Basics_of_H3_in_Fused/era5_temp_month/era5_temp_month.py
+++ b/public/Basics_of_H3_in_Fused/era5_temp_month/era5_temp_month.py
@@ -3,6 +3,13 @@ def udf(month='2024-05',
     bounds:fused.types.Bounds=[-125,32,-114,42],
     hex_res: int = 4
 ):
+    # month lands in the object path inside read_parquet(); keep it to YYYY-MM.
+    import re as _re
+    if not _re.fullmatch(r"\d{4}-\d{2}", str(month)):
+        raise ValueError(f"month must look like YYYY-MM, got {month!r}")
+    # bounds only guarantees four elements, not four numbers: coerce before
+    # they reach the query.
+    bounds = [float(v) for v in bounds]
     path = f's3://fused-asset/data/era5/t2m_daily_mean_v4_1000/month={month}/0.parquet'
     
     common = fused.load("https://github.com/fusedio/udfs/tree/56ec615/public/common/")

--- a/public/Basics_of_H3_in_Fused/era5_temp_month_hex4/era5_temp_month_hex4.py
+++ b/public/Basics_of_H3_in_Fused/era5_temp_month_hex4/era5_temp_month_hex4.py
@@ -3,6 +3,13 @@ def udf(month='2024-05',
     bounds:fused.types.Bounds=[-130, 25, -60, 50],
     hex_res: int = 4
 ):
+    # month lands in the object path inside read_parquet(); keep it to YYYY-MM.
+    import re as _re
+    if not _re.fullmatch(r"\d{4}-\d{2}", str(month)):
+        raise ValueError(f"month must look like YYYY-MM, got {month!r}")
+    # bounds only guarantees four elements, not four numbers: coerce before
+    # they reach the query.
+    bounds = [float(v) for v in bounds]
     path = f's3://fused-asset/data/era5/t2m_daily_mean_v4_1000/month={month}/0.parquet'
 
     # This loads DuckDB with the spatial & H3 extensions directly

--- a/public/Basics_of_H3_in_Fused/era5_temp_monthly_average/era5_temp_monthly_average.py
+++ b/public/Basics_of_H3_in_Fused/era5_temp_monthly_average/era5_temp_monthly_average.py
@@ -2,6 +2,13 @@
 def udf(month='2024-05',
     bounds:fused.types.Bounds=[-125,32,-114,42]
 ):
+    # month lands in the object path inside read_parquet(); keep it to YYYY-MM.
+    import re as _re
+    if not _re.fullmatch(r"\d{4}-\d{2}", str(month)):
+        raise ValueError(f"month must look like YYYY-MM, got {month!r}")
+    # bounds only guarantees four elements, not four numbers: coerce before
+    # they reach the query.
+    bounds = [float(v) for v in bounds]
     path = f's3://fused-asset/data/era5/t2m_daily_mean_v4_1000/month={month}/0.parquet'
     
     common = fused.load("https://github.com/fusedio/udfs/tree/56ec615/public/common/")

--- a/public/DuckDB_NYC_Example/DuckDB_NYC_Example.py
+++ b/public/DuckDB_NYC_Example/DuckDB_NYC_Example.py
@@ -1,6 +1,6 @@
 # Note: This UDF is only for demo purposes. You may get `HTTP GET error` after several times calling it. This is the data retrieval issue caused by Cloudfront servers not responding.
 @fused.udf
-def udf(agg_factor=3, min_count=5):
+def udf(agg_factor: int = 3, min_count: int = 5):
     import duckdb
 
     common = fused.load("https://github.com/fusedio/udfs/tree/3991434/public/common/")


### PR DESCRIPTION
Eleven UDFs put caller-supplied values into a query or a page without interpreting them. Per [Write UDFs securely](https://docs.fused.io/guide/working-with-udfs/udf-best-practices/security): values are bound or coerced, and names come from an allowlist in code.

**A path or URL parameter is deliberately not treated as a problem here.** These run in a public environment where reading is fine, and `files/` takes a path by design because Workbench substitutes it. What's fixed is values arriving *uninterpreted*.

## SQL

| Fix | Where |
|---|---|
| `bounds` elements coerced with `float()` | 6 UDFs |
| `month` checked against `YYYY-MM` | the 5 era5 UDFs |
| `agg_factor` / `min_count` annotated `int` | `DuckDB_NYC_Example` |
| `path` / `noise_311_link` bound as `?` | `nyc_dashboard_witt_ai`, `ny411_noise_sample_h3` |

Two of these are worth spelling out:

- **`bounds` is not what it looks like.** `convert_to_bounds` (`fused-py/_udf/args.py:167`) checks `len(val) == 4` and nothing else — it does *not* coerce the elements. Four strings pass that check and land in the query. Same root cause as the `Sentinel2_Band_Urls` fix in fusedlabs/fusedudfs#2284.
- **`month` reaches SQL indirectly.** It builds the object path inside `read_parquet('{path}')`, so a parameter-to-SQL scan doesn't see it. I only caught it by reading the file.
- **`DuckDB_NYC_Example` needed nothing but annotations.** `def udf(agg_factor=3, min_count=5)` had no annotations at all, so `coerce_arg` did nothing. Annotating `int` is the whole fix — the runtime coerces from the annotation before the body runs.

## Returned HTML

- **`chart_js_generator`** — `version` selects the CDN script the page loads (`chart.js@{version}/dist/chart.umd.min.js`), so it chooses which code runs, not just what text appears; `background` lands in CSS. Both are now checked against a known shape.
- **`Hex_Tile_Map_Incidence`** — four values went into a `<script>` block via the `{x!r}` conversion. **Neither `repr()` nor `{x!r}` escapes `</script>`** — the HTML parser closes the tag before JS ever sees it. Now JSON-encoded with `</` escaped, in locals rather than inline (f-string expressions can't contain backslashes before Python 3.12).

## Left alone deliberately

- **The SQL-console demos** whose purpose is to take SQL from the caller: `Duckdb_Table_from_UDF`, `Duckdb_Table_loading_from_s3`, `Simple_Map_Duckdb_WASM_with_input`, `Show_Me_Tomato`. Same reasoning as `files/` taking a path.
- **`community/sina/common_deprecated`** — `exec(requests.get(url).text, module)`, remote code execution by construction. Deprecated, so deleting may beat fixing.
- **`public/common/common.py`'s `from_pickle` and `from_path`** — no caller anywhere in the repo, so nothing is exploitable today. Worth knowing that "reading files from a public environment is fine" doesn't extend to these: `from_path` doesn't read a file, it executes it. A docstring warning is probably enough.

## Three candidates dropped after checking

- `CDLs_Tile_Example`'s `image_format` never reaches SQL — my scan matched the word "from" in *"Please pick from (png, jpg…)"*.
- `H3_From_To_Pos`'s `path` parameter is overwritten by a hardcoded value on the line before the query. Dead parameter, not exploitable.
- The Mapbox `pk.` token (29 files) is a public token that must reach the browser to render a map, so moving it wouldn't hide it.

## Verification

- All eleven files parse; every `?` added has its value bound.
- DuckDB 1.5.5 accepts `read_parquet(?)`, `read_csv_auto(?)` and bound `BETWEEN` operands — checked directly rather than assumed.
- The guards reject the crafted inputs (`month="2024-05') UNION SELECT 1--"`, `version="4/../../evil.js"`, `bounds=["1","2","3","0 OR 1=1--"]`) and accept every existing default.

Not verified: none of these UDFs was executed against live data — the environment this was prepared in can't reach the source endpoints. Changes are confined to how values are interpreted; no query logic or output shape moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NSBjx8MebKUH6WrrK3AL8R

---
_Generated by [Claude Code](https://claude.ai/code/session_01NSBjx8MebKUH6WrrK3AL8R)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches many public/community UDFs at input-validation boundaries (SQL injection and script-breakout paths); changes are narrow guards and parameter binding with no altered business logic.
> 
> **Overview**
> Hardens **eleven UDFs** so caller-supplied values are validated or bound before they reach DuckDB SQL or embedded HTML/JS, without changing query logic or output shape.
> 
> **SQL-facing inputs:** Five ERA5-style UDFs (plus `era5_hex_mean_temp_foss4g`) now require `month` to match `YYYY-MM` before it is used in the parquet path, and six UDFs coerce `bounds` with `float()` so non-numeric elements cannot break `BETWEEN` clauses. `nyc_dashboard_witt_ai` and `ny411_noise_sample_h3` switch file paths/URLs from string interpolation to DuckDB placeholders (`read_parquet(?)`, `read_csv_auto(?)`). `DuckDB_NYC_Example` adds `int` annotations on `agg_factor` and `min_count` so the runtime coerces them before they appear in the SQL expression.
> 
> **HTML/JS outputs:** `Hex_Tile_Map_Incidence` replaces `{x!r}` in `<script>` with JSON-encoded literals and escapes `</` so a token or config cannot prematurely close the script tag. `chart_js_generator` rejects malformed `version` (CDN script URL) and `background` (CSS) with regex allowlists.
> 
> Deliberately unchanged: interactive SQL-console demos, deprecated remote-`exec` utilities, and path parameters where public read-by-path is intentional.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de8a34af0e8c9dc2ec74708c9287f0eaa2c33e1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->